### PR TITLE
feat: add redis-cli to dbc

### DIFF
--- a/recipes-extended/redis/redis_%.bbappend
+++ b/recipes-extended/redis/redis_%.bbappend
@@ -4,8 +4,8 @@ SRC_URI += "file://redis.conf"
 SRC_URI += " file://redis-sysctl.conf"
 SRC_URI += " file://redis.service"
 
-# For DBC machine, only package redis-cli
-PACKAGES:${MACHINE} = "${@'${PN}-cli' if d.getVar('MACHINE') == 'librescoot-dbc' else '${PN} ${PN}-cli ${PN}-server'}"
+PACKAGES += "${PN}-client"
+FILES:${PN}-client = "${bindir}/redis-cli ${bindir}/redis-benchmark"
 
 do_install:append() {
     install -d ${D}${sysconfdir}
@@ -15,13 +15,4 @@ do_install:append() {
     install -m 0644 ${WORKDIR}/redis.conf ${D}${sysconfdir}/redis/redis.conf
     install -m 0644 ${WORKDIR}/redis-sysctl.conf ${D}${sysconfdir}/sysctl.d/redis-sysctl.conf
     install -m 0644 ${WORKDIR}/redis.service ${D}${systemd_system_unitdir}
-}
-
-# Remove server files for DBC machine
-do_install:append:librescoot-dbc() {
-    rm -f ${D}${bindir}/redis-server
-    rm -f ${D}${bindir}/redis-sentinel
-    rm -f ${D}${sysconfdir}/redis/redis.conf
-    rm -f ${D}${sysconfdir}/sysctl.d/redis-sysctl.conf
-    rm -f ${D}${systemd_system_unitdir}/redis.service
 }

--- a/recipes-extended/redis/redis_%.bbappend
+++ b/recipes-extended/redis/redis_%.bbappend
@@ -4,6 +4,9 @@ SRC_URI += "file://redis.conf"
 SRC_URI += " file://redis-sysctl.conf"
 SRC_URI += " file://redis.service"
 
+# For DBC machine, only package redis-cli
+PACKAGES:${MACHINE} = "${@'${PN}-cli' if d.getVar('MACHINE') == 'librescoot-dbc' else '${PN} ${PN}-cli ${PN}-server'}"
+
 do_install:append() {
     install -d ${D}${sysconfdir}
     install -d ${D}${sysconfdir}/sysctl.d/
@@ -12,4 +15,13 @@ do_install:append() {
     install -m 0644 ${WORKDIR}/redis.conf ${D}${sysconfdir}/redis/redis.conf
     install -m 0644 ${WORKDIR}/redis-sysctl.conf ${D}${sysconfdir}/sysctl.d/redis-sysctl.conf
     install -m 0644 ${WORKDIR}/redis.service ${D}${systemd_system_unitdir}
+}
+
+# Remove server files for DBC machine
+do_install:append:librescoot-dbc() {
+    rm -f ${D}${bindir}/redis-server
+    rm -f ${D}${bindir}/redis-sentinel
+    rm -f ${D}${sysconfdir}/redis/redis.conf
+    rm -f ${D}${sysconfdir}/sysctl.d/redis-sysctl.conf
+    rm -f ${D}${systemd_system_unitdir}/redis.service
 }

--- a/recipes-fsl/images/librescoot-dbc-image.bb
+++ b/recipes-fsl/images/librescoot-dbc-image.bb
@@ -33,7 +33,7 @@ CORE_IMAGE_EXTRA_INSTALL += " \
     python3-pyyaml \
     python3-aioredis \
     python3-redis \
-    redis-cli \
+    redis-client \
     python3-cbor2 \
     python3-smbus2 \
     python3-typing-extensions \

--- a/recipes-fsl/images/librescoot-dbc-image.bb
+++ b/recipes-fsl/images/librescoot-dbc-image.bb
@@ -33,6 +33,7 @@ CORE_IMAGE_EXTRA_INSTALL += " \
     python3-pyyaml \
     python3-aioredis \
     python3-redis \
+    redis-cli \
     python3-cbor2 \
     python3-smbus2 \
     python3-typing-extensions \


### PR DESCRIPTION
Add a package that only contains redis-cli, and remove superfluous binaries for DBC install.
Should make the redis-cli binary available on the DBC.