### PR TITLE
feat: add alarm-service to Yocto build

### DIFF
--- a/recipes-core/alarm-service/alarm-service.bb
+++ b/recipes-core/alarm-service/alarm-service.bb
@@ -1,0 +1,31 @@
+SUMMARY = "LibreScoot Alarm Service"
+HOMEPAGE = "https://github.com/librescoot/alarm-service"
+LICENSE = "CC-BY-NC-4.0"
+LIC_FILES_CHKSUM = "file://src/alarm-service/LICENSE;md5=f5a53c7ab38ba3772e879f1407d3d412"
+
+SRC_URI = "git://github.com/librescoot/alarm-service.git;protocol=https;branch=main"
+SRC_URI += " file://librescoot-alarm.service"
+
+SRCREV = "${AUTOREV}"
+
+S = "${WORKDIR}/git"
+
+inherit go-mod systemd
+
+GO_IMPORT = "alarm-service"
+
+GO_LINKSHARED = ""
+GOBUILDFLAGS:remove = "-buildmode=pie"
+
+FILES:${PN} += "/usr/lib/systemd/system/librescoot-alarm.service"
+
+SYSTEMD_SERVICE:${PN} = "librescoot-alarm.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -d ${D}${systemd_system_unitdir}
+
+    install -m 0755 ${B}/bin/linux_arm/alarm-service ${D}${bindir}/
+    install -m 0644 ${WORKDIR}/librescoot-alarm.service ${D}${systemd_system_unitdir}
+}

--- a/recipes-core/alarm-service/files/librescoot-alarm.service
+++ b/recipes-core/alarm-service/files/librescoot-alarm.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=LibreScoot Alarm Service
+After=redis.service librescoot-vehicle.service librescoot-settings.service
+Wants=redis.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/alarm-service \
+    --i2c-bus=/dev/i2c-3 \
+    --redis=localhost:6379 \
+    --log-level=info \
+    --alarm-duration=10
+Restart=always
+RestartSec=5
+User=root
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Integrates motion-detection alarm system into LibreScoot image. Service starts after vehicle-service and settings-service to ensure required Redis channels are available. Horn disabled by default, controlled via Redis settings.

See [librescoot/alarm-service](https://github.com/librescoot/alarm-service) for details.