### PR TITLE
feat: add shell aliases and hostname resolution for MDB/DBC

### DIFF
--- a/recipes-core/shell-config/files/hosts-dbc
+++ b/recipes-core/shell-config/files/hosts-dbc
@@ -1,0 +1,2 @@
+# MDB hostname alias (for DBC)
+192.168.7.1	mdb

--- a/recipes-core/shell-config/files/hosts-mdb
+++ b/recipes-core/shell-config/files/hosts-mdb
@@ -1,0 +1,2 @@
+# DBC hostname alias (for MDB)
+192.168.7.2	dbc

--- a/recipes-core/shell-config/files/librescoot-aliases-dbc.sh
+++ b/recipes-core/shell-config/files/librescoot-aliases-dbc.sh
@@ -1,15 +1,18 @@
 #!/bin/sh
 # LibreScoot shell aliases for DBC
 
+# Default redis-cli to connect to MDB
+alias redis-cli='redis-cli -h mdb'
+
 # Redis CLI shortcuts (connect to MDB)
-alias hgetall='redis-cli -h mdb hgetall'
-alias hget='redis-cli -h mdb hget'
-alias hset='redis-cli -h mdb hset'
-alias hdel='redis-cli -h mdb hdel'
-alias publish='redis-cli -h mdb publish'
-alias lpush='redis-cli -h mdb lpush'
-alias lrange='redis-cli -h mdb lrange'
-alias keys='redis-cli -h mdb keys'
+alias hgetall='redis-cli hgetall'
+alias hget='redis-cli hget'
+alias hset='redis-cli hset'
+alias hdel='redis-cli hdel'
+alias publish='redis-cli publish'
+alias lpush='redis-cli lpush'
+alias lrange='redis-cli lrange'
+alias keys='redis-cli keys'
 
 # SSH shortcuts
 alias mdb='ssh root@mdb'

--- a/recipes-core/shell-config/files/librescoot-aliases-dbc.sh
+++ b/recipes-core/shell-config/files/librescoot-aliases-dbc.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# LibreScoot shell aliases for DBC
+
+# Redis CLI shortcuts (connect to MDB)
+alias hgetall='redis-cli -h mdb hgetall'
+alias hget='redis-cli -h mdb hget'
+alias hset='redis-cli -h mdb hset'
+alias hdel='redis-cli -h mdb hdel'
+alias publish='redis-cli -h mdb publish'
+alias lpush='redis-cli -h mdb lpush'
+alias lrange='redis-cli -h mdb lrange'
+alias keys='redis-cli -h mdb keys'
+
+# SSH shortcuts
+alias mdb='ssh root@mdb'
+
+# Service management
+alias svc='lsc svc'

--- a/recipes-core/shell-config/files/librescoot-aliases.sh
+++ b/recipes-core/shell-config/files/librescoot-aliases.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# LibreScoot shell aliases
+
+# Redis CLI shortcuts
+alias hgetall='redis-cli hgetall'
+alias hget='redis-cli hget'
+alias hset='redis-cli hset'
+alias hdel='redis-cli hdel'
+alias publish='redis-cli publish'
+alias lpush='redis-cli lpush'
+alias lrange='redis-cli lrange'
+alias keys='redis-cli keys'
+
+# SSH shortcuts
+alias dbc='ssh root@dbc'
+
+# Service management
+alias svc='lsc svc'

--- a/recipes-core/shell-config/files/redis-cli-env-dbc.sh
+++ b/recipes-core/shell-config/files/redis-cli-env-dbc.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Redis CLI default host for DBC
+
+export REDISCLI_HOST=mdb

--- a/recipes-core/shell-config/files/redis-cli-env-dbc.sh
+++ b/recipes-core/shell-config/files/redis-cli-env-dbc.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-# Redis CLI default host for DBC
-
-export REDISCLI_HOST=mdb

--- a/recipes-core/shell-config/shell-config.bb
+++ b/recipes-core/shell-config/shell-config.bb
@@ -1,0 +1,55 @@
+DESCRIPTION = "LibreScoot shell configuration and aliases"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://librescoot-aliases.sh \
+    file://librescoot-aliases-dbc.sh \
+    file://redis-cli-env-dbc.sh \
+    file://hosts-mdb \
+    file://hosts-dbc \
+"
+
+S = "${WORKDIR}"
+
+FILES:${PN} = " \
+    /etc/profile.d/librescoot-aliases.sh \
+    /etc/profile.d/redis-cli-env.sh \
+    /etc/hosts-extra \
+"
+
+do_install () {
+    install -d ${D}${sysconfdir}/profile.d
+    install -d ${D}${sysconfdir}
+}
+
+do_install:append:unu-mdb () {
+    # Install MDB-specific aliases
+    install -m 0755 ${WORKDIR}/librescoot-aliases.sh ${D}${sysconfdir}/profile.d/
+
+    # Install hosts entry for DBC
+    install -m 0644 ${WORKDIR}/hosts-mdb ${D}${sysconfdir}/hosts-extra
+}
+
+do_install:append:unu-dbc () {
+    # Install DBC-specific aliases (with -h mdb)
+    install -m 0755 ${WORKDIR}/librescoot-aliases-dbc.sh ${D}${sysconfdir}/profile.d/librescoot-aliases.sh
+
+    # Set default redis-cli host
+    install -m 0755 ${WORKDIR}/redis-cli-env-dbc.sh ${D}${sysconfdir}/profile.d/redis-cli-env.sh
+
+    # Install hosts entry for MDB
+    install -m 0644 ${WORKDIR}/hosts-dbc ${D}${sysconfdir}/hosts-extra
+}
+
+pkg_postinst:${PN} () {
+    #!/bin/sh
+    if [ -z "$D" ] && [ -f /etc/hosts-extra ]; then
+        # Running on target, append to /etc/hosts if not already present
+        if ! grep -qf /etc/hosts-extra /etc/hosts 2>/dev/null; then
+            cat /etc/hosts-extra >> /etc/hosts
+        fi
+    fi
+}
+
+RDEPENDS:${PN} += "redis"

--- a/recipes-core/shell-config/shell-config.bb
+++ b/recipes-core/shell-config/shell-config.bb
@@ -5,7 +5,6 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 SRC_URI = " \
     file://librescoot-aliases.sh \
     file://librescoot-aliases-dbc.sh \
-    file://redis-cli-env-dbc.sh \
     file://hosts-mdb \
     file://hosts-dbc \
 "
@@ -14,7 +13,6 @@ S = "${WORKDIR}"
 
 FILES:${PN} = " \
     /etc/profile.d/librescoot-aliases.sh \
-    /etc/profile.d/redis-cli-env.sh \
     /etc/hosts-extra \
 "
 
@@ -34,9 +32,6 @@ do_install:append:unu-mdb () {
 do_install:append:unu-dbc () {
     # Install DBC-specific aliases (with -h mdb)
     install -m 0755 ${WORKDIR}/librescoot-aliases-dbc.sh ${D}${sysconfdir}/profile.d/librescoot-aliases.sh
-
-    # Set default redis-cli host
-    install -m 0755 ${WORKDIR}/redis-cli-env-dbc.sh ${D}${sysconfdir}/profile.d/redis-cli-env.sh
 
     # Install hosts entry for MDB
     install -m 0644 ${WORKDIR}/hosts-dbc ${D}${sysconfdir}/hosts-extra

--- a/recipes-fsl/images/librescoot-dbc-image.bb
+++ b/recipes-fsl/images/librescoot-dbc-image.bb
@@ -55,6 +55,7 @@ CORE_IMAGE_EXTRA_INSTALL += " \
     brightness-reader \
     dbc-backlight-service \
     lsc \
+    shell-config \
     screen \
     chrony \
     chronyc \

--- a/recipes-fsl/images/librescoot-mdb-image.bb
+++ b/recipes-fsl/images/librescoot-mdb-image.bb
@@ -72,6 +72,7 @@ CORE_IMAGE_EXTRA_INSTALL += " \
     settings-service \
     alarm-service \
     lsc \
+    shell-config \
     radio-gaga \
     iptables \
     mc \


### PR DESCRIPTION
## Summary

- Adds shell configuration recipe with Redis CLI shortcuts and hostname aliases
- MDB gets DBC hostname (192.168.7.2 → dbc), DBC gets MDB hostname (192.168.7.1 → mdb)
- DBC redis-cli aliased to automatically connect to MDB
- Provides convenient aliases for common Redis operations (hgetall, hget, hset, hdel, publish, lpush, lrange, keys)
- SSH shortcuts: `dbc` alias on MDB, `mdb` alias on DBC

## Implementation Details

**Platform-specific behavior:**
- MDB: Redis aliases connect to local Redis, includes `dbc` SSH alias
- DBC: Redis aliases include `-h mdb` flag, includes `mdb` SSH alias

**Files:**
- New recipe: `recipes-core/shell-config/`
- Profile scripts installed to `/etc/profile.d/` for automatic loading
- Hostname entries appended to `/etc/hosts` via postinst hook

## Test Plan

- [x] Build MDB image and verify aliases work on device
- [x] Build DBC image and verify Redis aliases connect to MDB
- [x] Test `ssh dbc` from MDB and `ssh mdb` from DBC
- [x] Verify `redis-cli` on DBC defaults to MDB without `-h` flag
- [x] Confirm aliases are available in new shell sessions