### PR TITLE
fix: disable link-local addressing on USB network interfaces

### DIFF
--- a/recipes-connectivity/dhcpcd/dhcpcd_%.bbappend
+++ b/recipes-connectivity/dhcpcd/dhcpcd_%.bbappend
@@ -9,3 +9,4 @@ do_install:append() {
 
 # Disable dhcpcd service on DBC - using systemd-networkd with static IP instead
 SYSTEMD_AUTO_ENABLE:${PN}:unu-dbc = "disable"
+SYSTEMD_AUTO_ENABLE:${PN}:librescoot-dbc-rpi4 = "disable"

--- a/recipes-connectivity/dhcpcd/dhcpcd_%.bbappend
+++ b/recipes-connectivity/dhcpcd/dhcpcd_%.bbappend
@@ -6,3 +6,6 @@ do_install:append() {
     install -d ${D}${sysconfdir}
     install -m 0644 ${WORKDIR}/dhcpcd.conf ${D}${sysconfdir}/dhcpcd.conf
 }
+
+# Disable dhcpcd service on DBC - using systemd-networkd with static IP instead
+SYSTEMD_AUTO_ENABLE:${PN}:unu-dbc = "disable"

--- a/recipes-connectivity/mdb-netconfig/files/10-usb0.network
+++ b/recipes-connectivity/mdb-netconfig/files/10-usb0.network
@@ -4,3 +4,4 @@ Name=usb0
 [Network]
 ConfigureWithoutCarrier=yes
 Address=192.168.7.1/24
+LinkLocalAddressing=no


### PR DESCRIPTION
## Summary

Resolves conflicts between dhcpcd and systemd-networkd that were causing unwanted 169.254.x/16 link-local addresses on the usb0 interface for both MDB and DBC.

## Changes

**MDB (`recipes-connectivity/mdb-netconfig/files/10-usb0.network`)**
- Added `LinkLocalAddressing=no` to systemd-networkd configuration for usb0
- Keeps dhcpcd running for cellular modem interface management

**DBC (`recipes-connectivity/dhcpcd/dhcpcd_%.bbappend`)**
- Disabled dhcpcd service via `SYSTEMD_AUTO_ENABLE:${PN}:unu-dbc = "disable"`
- DBC only needs static IP configuration via systemd-networkd

## Testing

- [x] Verified on live MDB hardware - link-local address removed, connectivity intact
- [x] Verified on live DBC hardware - link-local address removed, connectivity intact
- [x] Confirmed DBC ↔ MDB connectivity (192.168.7.2 ↔ 192.168.7.1)
- [x] USB gadget functionality unaffected

## Impact

- Eliminates network manager conflict
- Removes unnecessary 169.254.x addresses
- Maintains all required connectivity (USB ethernet, modem)
- No impact on USB gadget mode when MDB is connected to a computer