### PR TITLE
fix(shell-config): apply hosts entries at build time instead of runtime

### DIFF
--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"

--- a/recipes-core/base-files/files/librescoot-dbc-rpi4/hosts
+++ b/recipes-core/base-files/files/librescoot-dbc-rpi4/hosts
@@ -1,0 +1,11 @@
+127.0.0.1	localhost
+
+# The following lines are desirable for IPv6 capable hosts
+::1     localhost ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+
+# LibreScoot hostname alias
+192.168.7.1	mdb

--- a/recipes-core/base-files/files/unu-dbc/hosts
+++ b/recipes-core/base-files/files/unu-dbc/hosts
@@ -1,0 +1,11 @@
+127.0.0.1	localhost
+
+# The following lines are desirable for IPv6 capable hosts
+::1     localhost ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+
+# LibreScoot hostname alias
+192.168.7.1	mdb

--- a/recipes-core/base-files/files/unu-mdb/hosts
+++ b/recipes-core/base-files/files/unu-mdb/hosts
@@ -1,0 +1,11 @@
+127.0.0.1	localhost
+
+# The following lines are desirable for IPv6 capable hosts
+::1     localhost ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+
+# LibreScoot hostname alias
+192.168.7.2	dbc

--- a/recipes-core/shell-config/shell-config.bb
+++ b/recipes-core/shell-config/shell-config.bb
@@ -5,54 +5,31 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 SRC_URI = " \
     file://librescoot-aliases.sh \
     file://librescoot-aliases-dbc.sh \
-    file://hosts-mdb \
-    file://hosts-dbc \
 "
 
 S = "${WORKDIR}"
 
 FILES:${PN} = " \
     /etc/profile.d/librescoot-aliases.sh \
-    /etc/hosts-extra \
 "
 
 do_install () {
     install -d ${D}${sysconfdir}/profile.d
-    install -d ${D}${sysconfdir}
 }
 
 do_install:append:unu-mdb () {
     # Install MDB-specific aliases
     install -m 0755 ${WORKDIR}/librescoot-aliases.sh ${D}${sysconfdir}/profile.d/
-
-    # Install hosts entry for DBC
-    install -m 0644 ${WORKDIR}/hosts-mdb ${D}${sysconfdir}/hosts-extra
 }
 
 do_install:append:unu-dbc () {
     # Install DBC-specific aliases (with -h mdb)
     install -m 0755 ${WORKDIR}/librescoot-aliases-dbc.sh ${D}${sysconfdir}/profile.d/librescoot-aliases.sh
-
-    # Install hosts entry for MDB
-    install -m 0644 ${WORKDIR}/hosts-dbc ${D}${sysconfdir}/hosts-extra
 }
 
 do_install:append:librescoot-dbc-rpi4 () {
     # Install DBC-specific aliases for RPi4
     install -m 0755 ${WORKDIR}/librescoot-aliases-dbc.sh ${D}${sysconfdir}/profile.d/librescoot-aliases.sh
-
-    # Install hosts entry for MDB
-    install -m 0644 ${WORKDIR}/hosts-dbc ${D}${sysconfdir}/hosts-extra
-}
-
-pkg_postinst:${PN} () {
-    #!/bin/sh
-    if [ -z "$D" ] && [ -f /etc/hosts-extra ]; then
-        # Running on target, append to /etc/hosts if not already present
-        if ! grep -qf /etc/hosts-extra /etc/hosts 2>/dev/null; then
-            cat /etc/hosts-extra >> /etc/hosts
-        fi
-    fi
 }
 
 RDEPENDS:${PN} += "redis"


### PR DESCRIPTION
## Summary

Fixes the issue where hostname aliases (mdb/dbc) were not being added to `/etc/hosts` despite the shell aliases working correctly.

## Root Cause

The previous implementation used `pkg_postinst` to append `/etc/hosts-extra` to `/etc/hosts` at runtime, which was not working reliably.

## Changes

### Created base-files bbappend
- New recipe: `recipes-core/base-files/base-files_%.bbappend`
- Uses `FILESEXTRAPATHS` with machine-specific directory pattern (Yocto best practice)
- Machine-specific hosts files:
  - `files/unu-mdb/hosts` - adds `192.168.7.2 dbc` alias
  - `files/unu-dbc/hosts` - adds `192.168.7.1 mdb` alias  
  - `files/librescoot-dbc-rpi4/hosts` - adds `192.168.7.1 mdb` alias

### Updated shell-config recipe
- Removed hosts-related logic (postinst, hosts-extra files)
- Now only handles shell aliases (its original purpose)
- Cleaner separation of concerns

## Benefits

- Hosts entries are baked into the image at build time
- Works immediately after flashing (no runtime modification needed)
- Follows Yocto best practices for machine-specific configuration files
- Same reliability as shell aliases

## Test Plan

- [ ] Build and flash MDB image, verify `ping dbc` works
- [ ] Build and flash DBC image, verify `ping mdb` works
- [ ] Build and flash RPi4 image, verify `ping mdb` works
- [ ] Verify shell aliases still work (hgetall, etc.)