### PR TITLE
feat: add uplink-service recipe

### DIFF
--- a/recipes-core/uplink-service/files/librescoot-uplink.service
+++ b/recipes-core/uplink-service/files/librescoot-uplink.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=LibreScoot Uplink Service (Redis-IPC)
+After=network.target redis.service
+Requires=redis.service
+ConditionPathExists=/data/uplink.yml
+
+[Service]
+Type=simple
+WorkingDirectory=/data
+ExecStart=/usr/bin/uplink-service -config /data/uplink.yml
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-core/uplink-service/uplink-service.bb
+++ b/recipes-core/uplink-service/uplink-service.bb
@@ -1,0 +1,29 @@
+SUMMARY = "LibreScoot Uplink Service"
+HOMEPAGE = "https://github.com/librescoot/uplink-service"
+LICENSE = "AGPL-3.0-only"
+LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=eb1e647870add0502f8f010b19de32af"
+
+inherit go-mod systemd
+
+SRC_URI = "git://github.com/librescoot/uplink-service.git;protocol=https;branch=main"
+SRC_URI += " file://librescoot-uplink.service"
+
+SRCREV = "${AUTOREV}"
+S = "${WORKDIR}/git"
+
+GO_IMPORT = "github.com/librescoot/uplink-service"
+GO_LINKSHARED = ""
+GOBUILDFLAGS:remove = "-buildmode=pie"
+
+FILES:${PN} += "/usr/lib/systemd/system/librescoot-uplink.service"
+
+SYSTEMD_SERVICE:${PN} = "librescoot-uplink.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -d ${D}${systemd_system_unitdir}
+
+    install -m 0755 ${B}/bin/linux_arm/uplink-service ${D}${bindir}/
+    install -m 0644 ${WORKDIR}/librescoot-uplink.service ${D}${systemd_system_unitdir}
+}


### PR DESCRIPTION
## Summary
- Adds BitBake recipe for uplink-service
- Includes systemd service unit (librescoot-uplink.service)
- Depends on redis.service and requires /data/uplink.yml config

## Test plan
- [ ] Build image with recipe included
- [ ] Verify service starts correctly on target