### PR TITLE
feat(librescoot-go): Add shared bbclass for Go service versioning

### DIFF
--- a/classes/librescoot-go.bbclass
+++ b/classes/librescoot-go.bbclass
@@ -1,0 +1,94 @@
+# Class for LibreScoot Go services - versioning from git tags
+#
+# This class injects version information from git tags into Go binaries
+# via ldflags, similar to what the Makefile does with:
+#   -X main.version=$(git describe --tags --always --dirty)
+#
+# It also sets PV and PKGV to reflect the git-derived version.
+
+inherit go-mod
+
+# For PV, we use a git-based version from SRCPV
+SRCPV = "${@bb.fetch2.get_srcrev(d)}"
+
+# Use a PV format that includes git info
+PV = "0.0+git${SRCPV}"
+
+# PKGV will be set dynamically during do_package
+PKGV = "${LIBRESCOOT_GO_VERSION}"
+LIBRESCOOT_GO_VERSION ?= "${PV}"
+
+# Go needs network access to download modules during compile
+do_compile[network] = "1"
+
+# We prepend to do_compile to rebuild GOBUILDFLAGS with version info,
+# then let the standard go_do_compile run
+do_compile:prepend() {
+    # Find the git directory
+    GITDIR=""
+    if [ -n "${GO_IMPORT}" ] && [ -d "${S}/src/${GO_IMPORT}/.git" ]; then
+        GITDIR="${S}/src/${GO_IMPORT}"
+    elif [ -d "${S}/.git" ]; then
+        GITDIR="${S}"
+    fi
+
+    VERSION="unknown"
+    REVISION="unknown"
+
+    if [ -n "$GITDIR" ]; then
+        ORIGDIR="$(pwd)"
+        cd "$GITDIR"
+        VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "unknown")
+        REVISION=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+        cd "$ORIGDIR"
+        bbnote "librescoot-go: Found git version=$VERSION revision=$REVISION in $GITDIR"
+    else
+        bbnote "librescoot-go: No .git directory found, trying B directory"
+        # Check in B (build directory where go-mod puts sources)
+        if [ -d "${B}/src/${GO_IMPORT}/.git" ]; then
+            ORIGDIR="$(pwd)"
+            cd "${B}/src/${GO_IMPORT}"
+            VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "unknown")
+            REVISION=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+            cd "$ORIGDIR"
+            bbnote "librescoot-go: Found git version=$VERSION revision=$REVISION in ${B}/src/${GO_IMPORT}"
+        else
+            # Fallback: use SRCREV if available
+            if [ -n "${SRCREV}" ] && [ "${SRCREV}" != "INVALID" ] && [ "${SRCREV}" != "AUTOINC" ]; then
+                REVISION=$(echo "${SRCREV}" | cut -c1-8)
+                VERSION="0.0.0-g$REVISION"
+                bbnote "librescoot-go: Using SRCREV fallback version=$VERSION"
+            fi
+        fi
+    fi
+
+    # Save version for packaging
+    echo "$VERSION" > ${WORKDIR}/librescoot-go-version
+
+    # Build version ldflags - these match what the Makefile uses
+    # Note: Using $VERSION not ${VERSION} to get shell variable expansion
+    VERSION_LDFLAGS="-X main.version=$VERSION -X main.gitRevision=$REVISION"
+
+    # Rebuild GOBUILDFLAGS with our version info injected
+    # We need to insert VERSION_LDFLAGS into the ldflags string
+    # Original GO_LDFLAGS format: -ldflags="${GO_RPATH} ${GO_LINKMODE} ${GO_LINUXLOADER} ${GO_EXTRA_LDFLAGS} -extldflags '${GO_EXTLDFLAGS}'"
+    NEW_GO_LDFLAGS="-ldflags=${GO_RPATH} ${GO_LINKMODE} ${GO_LINUXLOADER} $VERSION_LDFLAGS -extldflags '${GO_EXTLDFLAGS}'"
+
+    # Export the new GOBUILDFLAGS (this overrides the environment variable)
+    export GOBUILDFLAGS="${GO_PARALLEL_BUILD} -v $NEW_GO_LDFLAGS -trimpath -modcacherw -buildmode=pie"
+
+    bbnote "librescoot-go: VERSION_LDFLAGS=$VERSION_LDFLAGS"
+}
+
+# Read the computed version for packaging
+python do_package:prepend() {
+    import os
+    version_file = os.path.join(d.getVar('WORKDIR'), 'librescoot-go-version')
+    if os.path.exists(version_file):
+        with open(version_file, 'r') as f:
+            version = f.read().strip()
+            if version and version != "unknown":
+                d.setVar('PKGV', version)
+                d.setVar('LIBRESCOOT_GO_VERSION', version)
+                bb.note("librescoot-go: Package version set to %s" % version)
+}

--- a/classes/librescoot-go.bbclass
+++ b/classes/librescoot-go.bbclass
@@ -21,15 +21,17 @@ LIBRESCOOT_GO_VERSION ?= "${PV}"
 # Go needs network access to download modules during compile
 do_compile[network] = "1"
 
-# We prepend to do_compile to rebuild GOBUILDFLAGS with version info,
-# then let the standard go_do_compile run
-do_compile:prepend() {
-    # Find the git directory
+# Override do_compile to inject version ldflags directly
+# We can't use prepend because GOBUILDFLAGS is already expanded in go_do_compile
+do_compile() {
+    export TMPDIR="${GOTMPDIR}"
+
+    # Find git directory and extract version
     GITDIR=""
-    if [ -n "${GO_IMPORT}" ] && [ -d "${S}/src/${GO_IMPORT}/.git" ]; then
-        GITDIR="${S}/src/${GO_IMPORT}"
-    elif [ -d "${S}/.git" ]; then
+    if [ -d "${S}/.git" ]; then
         GITDIR="${S}"
+    elif [ -n "${GO_IMPORT}" ] && [ -d "${S}/src/${GO_IMPORT}/.git" ]; then
+        GITDIR="${S}/src/${GO_IMPORT}"
     fi
 
     VERSION="unknown"
@@ -43,41 +45,32 @@ do_compile:prepend() {
         cd "$ORIGDIR"
         bbnote "librescoot-go: Found git version=$VERSION revision=$REVISION in $GITDIR"
     else
-        bbnote "librescoot-go: No .git directory found, trying B directory"
-        # Check in B (build directory where go-mod puts sources)
-        if [ -d "${B}/src/${GO_IMPORT}/.git" ]; then
-            ORIGDIR="$(pwd)"
-            cd "${B}/src/${GO_IMPORT}"
-            VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "unknown")
-            REVISION=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-            cd "$ORIGDIR"
-            bbnote "librescoot-go: Found git version=$VERSION revision=$REVISION in ${B}/src/${GO_IMPORT}"
-        else
-            # Fallback: use SRCREV if available
-            if [ -n "${SRCREV}" ] && [ "${SRCREV}" != "INVALID" ] && [ "${SRCREV}" != "AUTOINC" ]; then
-                REVISION=$(echo "${SRCREV}" | cut -c1-8)
-                VERSION="0.0.0-g$REVISION"
-                bbnote "librescoot-go: Using SRCREV fallback version=$VERSION"
-            fi
+        # Fallback: use SRCREV if available
+        if [ -n "${SRCREV}" ] && [ "${SRCREV}" != "INVALID" ] && [ "${SRCREV}" != "AUTOINC" ]; then
+            REVISION=$(echo "${SRCREV}" | cut -c1-8)
+            VERSION="0.0.0-g$REVISION"
+            bbnote "librescoot-go: Using SRCREV fallback version=$VERSION"
         fi
     fi
 
     # Save version for packaging
     echo "$VERSION" > ${WORKDIR}/librescoot-go-version
 
-    # Build version ldflags - these match what the Makefile uses
-    # Note: Using $VERSION not ${VERSION} to get shell variable expansion
+    # Build version ldflags
     VERSION_LDFLAGS="-X main.version=$VERSION -X main.gitRevision=$REVISION"
 
-    # Rebuild GOBUILDFLAGS with our version info injected
-    # We need to insert VERSION_LDFLAGS into the ldflags string
-    # Original GO_LDFLAGS format: -ldflags="${GO_RPATH} ${GO_LINKMODE} ${GO_LINUXLOADER} ${GO_EXTRA_LDFLAGS} -extldflags '${GO_EXTLDFLAGS}'"
-    NEW_GO_LDFLAGS="-ldflags=${GO_RPATH} ${GO_LINKMODE} ${GO_LINUXLOADER} $VERSION_LDFLAGS -extldflags '${GO_EXTLDFLAGS}'"
-
-    # Export the new GOBUILDFLAGS (this overrides the environment variable)
-    export GOBUILDFLAGS="${GO_PARALLEL_BUILD} -v $NEW_GO_LDFLAGS -trimpath -modcacherw -buildmode=pie"
+    # Build complete ldflags string matching go.bbclass format
+    GO_LDFLAGS_FULL="${GO_RPATH} ${GO_LINKMODE} ${GO_LINUXLOADER} $VERSION_LDFLAGS -extldflags '${GO_EXTLDFLAGS}'"
 
     bbnote "librescoot-go: VERSION_LDFLAGS=$VERSION_LDFLAGS"
+
+    if [ -n "${GO_INSTALL}" ]; then
+        if [ -n "${GO_LINKSHARED}" ]; then
+            ${GO} install ${GO_PARALLEL_BUILD} -v -ldflags="$GO_LDFLAGS_FULL" -trimpath -modcacherw `go_list_packages`
+            rm -rf ${B}/bin
+        fi
+        ${GO} install ${GO_LINKSHARED} ${GO_PARALLEL_BUILD} -v -ldflags="$GO_LDFLAGS_FULL" -trimpath -modcacherw `go_list_packages`
+    fi
 }
 
 # Read the computed version for packaging

--- a/recipes-core/alarm-service/alarm-service.bb
+++ b/recipes-core/alarm-service/alarm-service.bb
@@ -10,7 +10,7 @@ SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-inherit go-mod systemd
+inherit librescoot-go systemd
 
 GO_IMPORT = "alarm-service"
 

--- a/recipes-core/battery-service/battery-service.bb
+++ b/recipes-core/battery-service/battery-service.bb
@@ -3,6 +3,8 @@ HOMEPAGE = "https://github.com/librescoot/battery-service"
 LICENSE = "CC-BY-NC-SA-4.0"
 LIC_FILES_CHKSUM = "file://src/battery-service/LICENSE;md5=fb5d051e53001fdff7fec0f368f47190"
 
+PV = "1.0"
+
 SRC_URI = "git://github.com/librescoot/battery-service.git;protocol=https;branch=main"
 SRC_URI += " file://librescoot-battery.service"
 
@@ -10,7 +12,7 @@ SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-inherit go-mod systemd
+inherit librescoot-go systemd
 
 GO_IMPORT = "battery-service"
 

--- a/recipes-core/battery-service/battery-service.bb
+++ b/recipes-core/battery-service/battery-service.bb
@@ -3,8 +3,6 @@ HOMEPAGE = "https://github.com/librescoot/battery-service"
 LICENSE = "CC-BY-NC-SA-4.0"
 LIC_FILES_CHKSUM = "file://src/battery-service/LICENSE;md5=fb5d051e53001fdff7fec0f368f47190"
 
-PV = "1.0"
-
 SRC_URI = "git://github.com/librescoot/battery-service.git;protocol=https;branch=main"
 SRC_URI += " file://librescoot-battery.service"
 

--- a/recipes-core/bluetooth-service/bluetooth-service.bb
+++ b/recipes-core/bluetooth-service/bluetooth-service.bb
@@ -10,7 +10,7 @@ SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-inherit go-mod systemd
+inherit librescoot-go systemd
 
 GO_IMPORT = "github.com/librescoot/bluetooth-service"
 

--- a/recipes-core/dbc-backlight-service/dbc-backlight-service.bb
+++ b/recipes-core/dbc-backlight-service/dbc-backlight-service.bb
@@ -10,7 +10,7 @@ SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-inherit go-mod systemd
+inherit librescoot-go systemd
 
 GO_IMPORT = "github.com/librescoot/dbc-backlight-service"
 

--- a/recipes-core/ecu-service/ecu-service.bb
+++ b/recipes-core/ecu-service/ecu-service.bb
@@ -3,6 +3,8 @@ HOMEPAGE = "https://github.com/librescoot/ecu-service"
 LICENSE = "CC-BY-NC-SA-4.0"
 LIC_FILES_CHKSUM = "file://src/ecu-service/LICENSE;md5=fb5d051e53001fdff7fec0f368f47190"
 
+PV = "1.0"
+
 SRC_URI = "git://github.com/librescoot/ecu-service.git;protocol=https;branch=main"
 SRC_URI += " file://librescoot-ecu.service"
 
@@ -10,7 +12,7 @@ SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-inherit go-mod systemd
+inherit librescoot-go systemd
 
 GO_IMPORT = "ecu-service"
 

--- a/recipes-core/ecu-service/ecu-service.bb
+++ b/recipes-core/ecu-service/ecu-service.bb
@@ -3,8 +3,6 @@ HOMEPAGE = "https://github.com/librescoot/ecu-service"
 LICENSE = "CC-BY-NC-SA-4.0"
 LIC_FILES_CHKSUM = "file://src/ecu-service/LICENSE;md5=fb5d051e53001fdff7fec0f368f47190"
 
-PV = "1.0"
-
 SRC_URI = "git://github.com/librescoot/ecu-service.git;protocol=https;branch=main"
 SRC_URI += " file://librescoot-ecu.service"
 

--- a/recipes-core/lsc/lsc.bb
+++ b/recipes-core/lsc/lsc.bb
@@ -9,7 +9,7 @@ SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-inherit go-mod
+inherit librescoot-go
 
 GO_IMPORT = "lsc"
 

--- a/recipes-core/modem-service/modem-service.bb
+++ b/recipes-core/modem-service/modem-service.bb
@@ -10,7 +10,7 @@ SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-inherit go-mod systemd
+inherit librescoot-go systemd
 
 GO_IMPORT = "modem-service"
 

--- a/recipes-core/pm-service/pm-service.bb
+++ b/recipes-core/pm-service/pm-service.bb
@@ -9,7 +9,7 @@ SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-inherit go-mod systemd
+inherit librescoot-go systemd
 
 GO_IMPORT = "github.com/librescoot/pm-service"
 

--- a/recipes-core/settings-service/settings-service.bb
+++ b/recipes-core/settings-service/settings-service.bb
@@ -10,7 +10,7 @@ SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-inherit go-mod systemd
+inherit librescoot-go systemd
 
 GO_IMPORT = "github.com/librescoot/settings-service"
 

--- a/recipes-core/ums-service/ums-service.bb
+++ b/recipes-core/ums-service/ums-service.bb
@@ -10,7 +10,7 @@ SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-inherit go-mod systemd
+inherit librescoot-go systemd
 
 GO_IMPORT = "github.com/librescoot/ums-service"
 

--- a/recipes-core/update-service/update-service.bb
+++ b/recipes-core/update-service/update-service.bb
@@ -10,7 +10,7 @@ SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-inherit go-mod systemd
+inherit librescoot-go systemd
 
 GO_IMPORT = "github.com/librescoot/update-service"
 

--- a/recipes-core/uplink-service/uplink-service.bb
+++ b/recipes-core/uplink-service/uplink-service.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/librescoot/uplink-service"
 LICENSE = "AGPL-3.0-only"
 LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=eb1e647870add0502f8f010b19de32af"
 
-inherit go-mod systemd
+inherit librescoot-go systemd
 
 SRC_URI = "git://github.com/librescoot/uplink-service.git;protocol=https;branch=main"
 SRC_URI += " file://librescoot-uplink.service"

--- a/recipes-core/vehicle-service/vehicle-service.bb
+++ b/recipes-core/vehicle-service/vehicle-service.bb
@@ -38,7 +38,7 @@ SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-inherit go-mod systemd
+inherit librescoot-go systemd
 
 GO_IMPORT = "vehicle-service"
 

--- a/recipes-core/version-service/version-service.bb
+++ b/recipes-core/version-service/version-service.bb
@@ -9,7 +9,7 @@ SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-inherit go-mod systemd
+inherit librescoot-go systemd
 
 GO_IMPORT = "github.com/librescoot/version-service"
 

--- a/recipes-extended/radio-gaga/radio-gaga.bb
+++ b/recipes-extended/radio-gaga/radio-gaga.bb
@@ -10,7 +10,7 @@ SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 
-inherit go-mod systemd
+inherit librescoot-go systemd
 
 GO_IMPORT = "radio-gaga"
 

--- a/recipes-graphics/carplay-service/carplay-service.bb
+++ b/recipes-graphics/carplay-service/carplay-service.bb
@@ -12,7 +12,7 @@ DEPENDS += "libusb"
 
 S = "${WORKDIR}/git"
 
-inherit go-mod systemd pkgconfig
+inherit librescoot-go systemd pkgconfig
 
 GO_IMPORT = "github.com/mzyy94/gocarplay"
 


### PR DESCRIPTION
## Summary
- Add `librescoot-go.bbclass` that injects Git-based version info into Go binaries via ldflags (`-X main.version=...`, `-X main.gitRevision=...`)
- Remove hardcoded `PV` values from `battery-service.bb` and `ecu-service.bb` recipes
- Version is derived from `git describe --tags --always --dirty` at compile time

## Technical Details
The class overrides `do_compile()` to build version ldflags and call `go install` directly. This is necessary because BitBake expands `GOBUILDFLAGS` at parse time, so a prepend approach doesn't work.

## Test plan
- [x] Built full MDB image with all 15 Go services
- [x] Verified version strings embedded in binaries (e.g., battery-service shows `v0.1.2`, vehicle-service shows `v0.6.0`)