### PR TITLE
feat: fake-hwclock with build timestamp seeding

### DIFF
--- a/recipes-extended/fake-hwclock/fake-hwclock.bb
+++ b/recipes-extended/fake-hwclock/fake-hwclock.bb
@@ -1,0 +1,29 @@
+SUMMARY = "Save/restore system clock to/from a file across reboots"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
+
+inherit systemd
+
+SRC_URI = " \
+    file://fake-hwclock \
+    file://fake-hwclock-load.service \
+    file://fake-hwclock-save.service \
+"
+
+SYSTEMD_SERVICE:${PN} = "fake-hwclock-load.service fake-hwclock-save.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+do_install() {
+    install -d ${D}${sbindir}
+    install -m 0755 ${WORKDIR}/fake-hwclock ${D}${sbindir}/fake-hwclock
+
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/fake-hwclock-load.service ${D}${systemd_system_unitdir}/
+    install -m 0644 ${WORKDIR}/fake-hwclock-save.service ${D}${systemd_system_unitdir}/
+}
+
+FILES:${PN} = " \
+    ${sbindir}/fake-hwclock \
+    ${systemd_system_unitdir}/fake-hwclock-load.service \
+    ${systemd_system_unitdir}/fake-hwclock-save.service \
+"

--- a/recipes-extended/fake-hwclock/files/fake-hwclock
+++ b/recipes-extended/fake-hwclock/files/fake-hwclock
@@ -1,16 +1,11 @@
 #!/bin/sh
 # Save/restore system clock to a file across reboots.
 # On load: only advances the clock (does not roll back a valid RTC).
-# On save: only writes if the current time looks sane.
 FILE=/etc/fake-hwclock.data
-MIN_SANE_SEC=1735689600  # 2025-01-01 00:00:00 UTC
 
 case "${1:-load}" in
     save)
-        NOW_SEC=$(date -u +'%s')
-        if [ "$NOW_SEC" -ge "$MIN_SANE_SEC" ]; then
-            date -u +'%Y-%m-%d %H:%M:%S' > "$FILE"
-        fi
+        date -u +'%Y-%m-%d %H:%M:%S' > "$FILE"
         ;;
     load)
         [ -f "$FILE" ] || exit 0

--- a/recipes-extended/fake-hwclock/files/fake-hwclock
+++ b/recipes-extended/fake-hwclock/files/fake-hwclock
@@ -1,17 +1,23 @@
 #!/bin/sh
-# Minimal fake-hwclock: save/restore system clock to a file.
+# Save/restore system clock to a file across reboots.
+# On load: only advances the clock (does not roll back a valid RTC).
+# On save: only writes if the current time looks sane.
 FILE=/etc/fake-hwclock.data
+MIN_SANE_SEC=1735689600  # 2025-01-01 00:00:00 UTC
 
 case "${1:-load}" in
     save)
-        date -u +'%Y-%m-%d %H:%M:%S' > "$FILE"
+        NOW_SEC=$(date -u +'%s')
+        if [ "$NOW_SEC" -ge "$MIN_SANE_SEC" ]; then
+            date -u +'%Y-%m-%d %H:%M:%S' > "$FILE"
+        fi
         ;;
     load)
         [ -f "$FILE" ] || exit 0
         SAVED=$(cat "$FILE")
-        SAVED_EPOCH=$(date -u -d "$SAVED" +'%s' 2>/dev/null) || exit 0
-        CURRENT_EPOCH=$(date -u +'%s')
-        if [ "$SAVED_EPOCH" -gt "$CURRENT_EPOCH" ]; then
+        SAVED_SEC=$(date -u -d "$SAVED" +'%s' 2>/dev/null) || exit 0
+        NOW_SEC=$(date -u +'%s')
+        if [ "$SAVED_SEC" -gt "$NOW_SEC" ]; then
             date -u -s "$SAVED"
             hwclock -w 2>/dev/null || true
         fi

--- a/recipes-extended/fake-hwclock/files/fake-hwclock
+++ b/recipes-extended/fake-hwclock/files/fake-hwclock
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Minimal fake-hwclock: save/restore system clock to a file.
+FILE=/etc/fake-hwclock.data
+
+case "${1:-load}" in
+    save)
+        date -u +'%Y-%m-%d %H:%M:%S' > "$FILE"
+        ;;
+    load)
+        [ -f "$FILE" ] || exit 0
+        SAVED=$(cat "$FILE")
+        SAVED_EPOCH=$(date -u -d "$SAVED" +'%s' 2>/dev/null) || exit 0
+        CURRENT_EPOCH=$(date -u +'%s')
+        if [ "$SAVED_EPOCH" -gt "$CURRENT_EPOCH" ]; then
+            date -u -s "$SAVED"
+            hwclock -w 2>/dev/null || true
+        fi
+        ;;
+    *)
+        echo "Usage: fake-hwclock {load|save}" >&2
+        exit 1
+        ;;
+esac

--- a/recipes-extended/fake-hwclock/files/fake-hwclock-load.service
+++ b/recipes-extended/fake-hwclock/files/fake-hwclock-load.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Restore system clock from saved timestamp
+DefaultDependencies=no
+Before=sysinit.target time-sync.target chrony.service
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/fake-hwclock load
+RemainAfterExit=yes
+
+[Install]
+WantedBy=sysinit.target

--- a/recipes-extended/fake-hwclock/files/fake-hwclock-save.service
+++ b/recipes-extended/fake-hwclock/files/fake-hwclock-save.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Save system clock to fake-hwclock file
+DefaultDependencies=no
+Before=shutdown.target reboot.target halt.target
+After=time-sync.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/fake-hwclock save
+RemainAfterExit=yes
+
+[Install]
+WantedBy=halt.target reboot.target shutdown.target

--- a/recipes-fsl/images/librescoot-dbc-image.bb
+++ b/recipes-fsl/images/librescoot-dbc-image.bb
@@ -3,6 +3,8 @@ LICENSE = "MIT"
 
 inherit core-image
 
+require librescoot-hwclock-seed.inc
+
 PLATFORM_FLAVOR    = "mx6qsabresd"
 
 SPLASH = "plymouth"

--- a/recipes-fsl/images/librescoot-hwclock-seed.inc
+++ b/recipes-fsl/images/librescoot-hwclock-seed.inc
@@ -1,0 +1,19 @@
+# Install fake-hwclock and pre-seed it with the build timestamp.
+#
+# On first boot (or after RTC power loss) the system clock will be set to
+# approximately the image build time instead of the epoch. fake-hwclock then
+# updates the seed file on every shutdown, so subsequent boots use the
+# last-known-good time.
+
+CORE_IMAGE_EXTRA_INSTALL += "fake-hwclock"
+
+IMAGE_POSTPROCESS_COMMAND:append = " seed_fake_hwclock; "
+
+python seed_fake_hwclock() {
+    import time, os
+    rootfs = d.getVar('IMAGE_ROOTFS')
+    ts = time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime())
+    path = os.path.join(rootfs, 'etc', 'fake-hwclock.data')
+    with open(path, 'w') as f:
+        f.write(ts + '\n')
+}

--- a/recipes-fsl/images/librescoot-hwclock-seed.inc
+++ b/recipes-fsl/images/librescoot-hwclock-seed.inc
@@ -12,8 +12,17 @@ IMAGE_POSTPROCESS_COMMAND:append = " seed_fake_hwclock; "
 python seed_fake_hwclock() {
     import time, os
     rootfs = d.getVar('IMAGE_ROOTFS')
-    ts = time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime())
-    path = os.path.join(rootfs, 'etc', 'fake-hwclock.data')
-    with open(path, 'w') as f:
-        f.write(ts + '\n')
+    epoch = int(time.time())
+
+    # Seed fake-hwclock so first boot starts at build time, not epoch.
+    hwclock_path = os.path.join(rootfs, 'etc', 'fake-hwclock.data')
+    with open(hwclock_path, 'w') as f:
+        f.write(time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(epoch)) + '\n')
+
+    # Write build timestamp (epoch seconds) so userspace can determine
+    # whether the current system time is merely plausible (>= build time,
+    # set by fake-hwclock) or actually correct (synced by Chrony/GPS).
+    ts_path = os.path.join(rootfs, 'etc', 'build-timestamp')
+    with open(ts_path, 'w') as f:
+        f.write(str(epoch) + '\n')
 }

--- a/recipes-fsl/images/librescoot-mdb-image.bb
+++ b/recipes-fsl/images/librescoot-mdb-image.bb
@@ -3,6 +3,8 @@ LICENSE = "MIT"
 
 inherit core-image
 
+require librescoot-hwclock-seed.inc
+
 PLATFORM_FLAVOR    = "mx6ulevk"
 
 BAD_RECOMMENDATIONS += "busybox-syslog"


### PR DESCRIPTION
Installs a minimal `fake-hwclock` implementation (our own recipe, not from meta-oe which doesn't carry it at our pinned commit) and pre-seeds it at image build time.

## What this does

- **`/etc/fake-hwclock.data`** — seeded with build timestamp so first boot (or any boot after RTC power loss) starts at build time instead of epoch
- **`/etc/build-timestamp`** — epoch seconds of the build, for userspace to distinguish plausible time (≥ build timestamp, restored by fake-hwclock) from actually-correct time (Chrony/GPS synced)
- **`fake-hwclock-load.service`** — runs before chrony at boot, advances clock if saved time > RTC time
- **`fake-hwclock-save.service`** — saves current time on shutdown, so subsequent boots use last-known-good time

## Design notes

- Load only advances the clock (never rolls back a valid RTC) — differs from upstream Debian fake-hwclock which restores unconditionally; our SNVS RTC may hold a valid Chrony-synced time
- Save is unconditional (no MIN_SANE_SEC guard) — safe because load guarantees the clock is at least at build time before any save can happen