### PR TITLE
fix(linux-imx): disable BMX055 kernel drivers on MDB

### DIFF
--- a/recipes-kernel/linux/linux-imx/config-bmx055.cfg
+++ b/recipes-kernel/linux/linux-imx/config-bmx055.cfg
@@ -1,0 +1,9 @@
+# Disable BMX055 kernel drivers — alarm-service manages the BMX055
+# directly via I2C. The kernel drivers soft-reset the chip on probe,
+# clearing the accelerometer wake-up interrupt latch.
+# CONFIG_BMC150_ACCEL is not set
+# CONFIG_BMC150_ACCEL_I2C is not set
+# CONFIG_BMC150_ACCEL_SPI is not set
+# CONFIG_BMG160 is not set
+# CONFIG_BMG160_I2C is not set
+# CONFIG_BMG160_SPI is not set

--- a/recipes-kernel/linux/linux-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-imx_5.4.bb
@@ -32,6 +32,7 @@ SRC_URI = " ${KERNEL_SRC};branch=${SRCBRANCH} \
 SRC_URI:append:unu-mdb = " file://mdb_defconfig"
 SRC_URI:append:unu-mdb = " file://librescoot-mdb.dts"
 SRC_URI:append:unu-mdb = " file://config-iotop.cfg"
+SRC_URI:append:unu-mdb = " file://config-bmx055.cfg"
 
 SRC_URI:append:unu-dbc = " file://dbc_defconfig"
 SRC_URI:append:unu-dbc = " file://librescoot-dbc.dts"
@@ -49,6 +50,7 @@ COMPATIBLE_MACHINE = "(mx6|mx7|mx8)"
 
 KERNEL_CONFIG_FRAGMENTS:append:unu-mdb = " \
     ${WORKDIR}/config-iotop.cfg \
+    ${WORKDIR}/config-bmx055.cfg \
 "
 
 do_compile:prepend() {


### PR DESCRIPTION
## Summary
- Disable bmc150_accel and bmg160 kernel drivers via config fragment (`config-bmx055.cfg`)
- These drivers soft-reset the BMX055 on probe, clearing the accelerometer wake-up interrupt latch that alarm-service needs for motion-triggered hibernation wake
- alarm-service manages the BMX055 directly via I2C and unbinds these drivers at startup anyway

## Changes
- New `config-bmx055.cfg` disabling `CONFIG_BMC150_ACCEL{,_I2C,_SPI}` and `CONFIG_BMG160{,_I2C,_SPI}`
- Added fragment to `linux-imx_5.4.bb` SRC_URI and KERNEL_CONFIG_FRAGMENTS for unu-mdb

## Test plan
- [ ] Rebuild linux-imx for unu-mdb and verify BMX055 drivers are not loaded
- [ ] Verify alarm-service wake-from-hibernate works without driver interference