### PR TITLE
feat(identity): per-device hostname and stable machine-id from OCOTP UID

### DIFF
--- a/conf/machine/unu-dbc.conf
+++ b/conf/machine/unu-dbc.conf
@@ -46,3 +46,9 @@ MENDER_STORAGE_TOTAL_SIZE_MB = "2368"
 MENDER_FEATURES_ENABLE:append = " mender-uboot mender-image-sd"
 MENDER_FEATURES_DISABLE:append = " mender-grub mender-image-uefi"
 
+# Set hostname from OCOTP hardware UID via U-Boot pre-setup hook.
+# OCOTP_CFG0 shadow register (bank 0 word 1) at 0x021BC410 holds the lower
+# 32-bit UID word, unique per SoC. setenv concatenates its args with spaces,
+# so no inner quotes are needed even though bootargs contains spaces.
+MENDER_UBOOT_PRE_SETUP_COMMANDS = "setexpr uid_lo *0x021BC410; setenv _hn systemd.hostname=unu-dbc-\${uid_lo}; setenv bootargs \${bootargs} \${_hn}"
+

--- a/conf/machine/unu-mdb.conf
+++ b/conf/machine/unu-mdb.conf
@@ -46,3 +46,9 @@ MENDER_FEATURES_DISABLE:append = " mender-grub mender-image-uefi"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "linux-imx-led"
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "wireguard-module"
+
+# Set hostname from OCOTP hardware UID via U-Boot pre-setup hook.
+# OCOTP_CFG0 shadow register (bank 0 word 1) at 0x021BC410 holds the lower
+# 32-bit UID word, unique per SoC. setenv concatenates its args with spaces,
+# so no inner quotes are needed even though bootargs contains spaces.
+MENDER_UBOOT_PRE_SETUP_COMMANDS = "setexpr uid_lo *0x021BC410; setenv _hn systemd.hostname=unu-mdb-\${uid_lo}; setenv bootargs \${bootargs} \${_hn}"

--- a/recipes-core/machine-id-init/files/machine-id-init.service
+++ b/recipes-core/machine-id-init/files/machine-id-init.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Persist machine-id to U-Boot env
+DefaultDependencies=no
+After=local-fs.target
+Before=shutdown.target
+ConditionPathExists=/sys/bus/nvmem/devices/imx-ocotp0/nvmem
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/lib/machine-id-init/machine-id-init.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-core/machine-id-init/files/machine-id-init.sh
+++ b/recipes-core/machine-id-init/files/machine-id-init.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Persist machine-id across OTA updates by writing it to U-Boot env.
+# On first boot after flashing, mender_systemd_machine_id is empty, so
+# systemd generates a random machine-id and writes it to /etc/machine-id.
+# We read it and store it in U-Boot env so that subsequent boots (including
+# post-OTA boots) pass systemd.machine_id= on the kernel cmdline, giving a
+# stable machine-id tied to the device rather than the rootfs generation.
+
+NVMEM=/sys/bus/nvmem/devices/imx-ocotp0/nvmem
+
+current=$(fw_printenv mender_systemd_machine_id 2>/dev/null | sed 's/mender_systemd_machine_id=//')
+if [ -n "$current" ]; then
+    exit 0
+fi
+
+if [ ! -r "$NVMEM" ]; then
+    echo "machine-id-init: cannot read $NVMEM" >&2
+    exit 1
+fi
+
+# Read OCOTP CFG0+CFG1 (8 bytes at offset 4): lower 64 bits of hardware UID.
+# Each byte becomes 2 hex chars; od outputs space-separated pairs.
+uid=$(dd if="$NVMEM" bs=1 skip=4 count=8 2>/dev/null | od -A n -t x1 | tr -d ' \n')
+
+if [ "${#uid}" -ne 16 ]; then
+    echo "machine-id-init: unexpected UID length ${#uid}, expected 16" >&2
+    exit 1
+fi
+
+# machine-id requires exactly 32 lowercase hex chars; double the 16-char UID.
+machine_id="${uid}${uid}"
+
+fw_setenv mender_systemd_machine_id "$machine_id"
+echo "machine-id-init: set mender_systemd_machine_id=$machine_id (active from next boot)"

--- a/recipes-core/machine-id-init/files/machine-id-init.sh
+++ b/recipes-core/machine-id-init/files/machine-id-init.sh
@@ -19,8 +19,7 @@ if [ ! -r "$NVMEM" ]; then
 fi
 
 # Read OCOTP CFG0+CFG1 (8 bytes at offset 4): lower 64 bits of hardware UID.
-# Each byte becomes 2 hex chars; od outputs space-separated pairs.
-uid=$(dd if="$NVMEM" bs=1 skip=4 count=8 2>/dev/null | od -A n -t x1 | tr -d ' \n')
+uid=$(od -A n -t x1 -j 4 -N 8 "$NVMEM" | tr -d ' \n')
 
 if [ "${#uid}" -ne 16 ]; then
     echo "machine-id-init: unexpected UID length ${#uid}, expected 16" >&2

--- a/recipes-core/machine-id-init/files/machine-id-init.sh
+++ b/recipes-core/machine-id-init/files/machine-id-init.sh
@@ -18,8 +18,8 @@ if [ ! -r "$NVMEM" ]; then
     exit 1
 fi
 
-# Read OCOTP CFG0+CFG1 (8 bytes at offset 4): lower 64 bits of hardware UID.
-uid=$(od -A n -t x1 -j 4 -N 8 "$NVMEM" | tr -d ' \n')
+# Read OCOTP_CFG0+CFG1 as 32-bit words (native endian, matches U-Boot's view).
+uid=$(od -A n -t x4 -j 4 -N 8 "$NVMEM" | tr -d ' \n')
 
 if [ "${#uid}" -ne 16 ]; then
     echo "machine-id-init: unexpected UID length ${#uid}, expected 16" >&2

--- a/recipes-core/machine-id-init/machine-id-init.bb
+++ b/recipes-core/machine-id-init/machine-id-init.bb
@@ -1,0 +1,20 @@
+LICENSE = "CLOSED"
+LIC_FILES_CHKSUM = ""
+
+inherit systemd
+
+SRC_URI = "file://machine-id-init.sh \
+           file://machine-id-init.service"
+
+SYSTEMD_SERVICE:${PN} = "machine-id-init.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+RDEPENDS:${PN} = "u-boot-fw-utils"
+
+do_install() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/machine-id-init.service ${D}${systemd_system_unitdir}
+
+    install -d ${D}${libdir}/machine-id-init
+    install -m 0755 ${WORKDIR}/machine-id-init.sh ${D}${libdir}/machine-id-init/machine-id-init.sh
+}

--- a/recipes-fsl/images/librescoot-dbc-image.bb
+++ b/recipes-fsl/images/librescoot-dbc-image.bb
@@ -44,6 +44,7 @@ CORE_IMAGE_EXTRA_INSTALL += " \
     scootui \
     dbc-dispatcher \
     onboot-service \
+    machine-id-init \
     version-service \
     update-service \
     dbc-backlight-service \

--- a/recipes-fsl/images/librescoot-mdb-image.bb
+++ b/recipes-fsl/images/librescoot-mdb-image.bb
@@ -66,6 +66,7 @@ CORE_IMAGE_EXTRA_INSTALL += " \
     battery-service \
     modem-service \
     onboot-service \
+    machine-id-init \
     bluetooth-service \
     version-service \
     pm-service \


### PR DESCRIPTION
## Summary

Two things: unique per-device hostnames, and a stable machine-id that survives OTA updates. Both derived from the i.MX OCOTP hardware UID (fuse-burned, unique per SoC).

Hostnames are set from U-Boot before the kernel boots. Reads OCOTP_CFG0 at `0x021BC410` via `setexpr`, passes `systemd.hostname=unu-{mdb,dbc}-<uid>` on the kernel cmdline through `MENDER_UBOOT_PRE_SETUP_COMMANDS`. Every journal entry from PID 1 onward has the right hostname, no userspace service needed.

Machine-id persistence is a new `machine-id-init` oneshot that runs on first boot: reads the same UID from nvmem, doubles the 16-char hex to 32 chars (machine-id format), writes it to `mender_systemd_machine_id` in U-Boot env via `fw_setenv`. The existing `mender_setup` script already passes this on the cmdline as `systemd.machine_id=` on subsequent boots.

Tested on deep-blue DBC – hostname `unu-dbc-ee6ba0ab` confirmed in journal.

## Test plan

- [x] Hostname verified on deep-blue DBC
- [x] Full image build with `machine-id-init` included
- [x] Verify `fw_setenv mender_systemd_machine_id` persists and takes effect after reboot
- [x] Verify MDB hostname after U-Boot rebuild