### PR TITLE
fix(dbc): remove package-management IMAGE_FEATURE

### DIFF
--- a/recipes-fsl/images/librescoot-dbc-image.bb
+++ b/recipes-fsl/images/librescoot-dbc-image.bb
@@ -11,7 +11,6 @@ BAD_RECOMMENDATIONS += "busybox-syslog"
 
 IMAGE_FEATURES += " \
     debug-tweaks \
-    package-management \
     ssh-server-dropbear \
     hwcodecs \
 "


### PR DESCRIPTION
Removes the `package-management` IMAGE_FEATURE from the DBC image.

This feature pulls in `dnf` and its full Python dependency tree (~46MB installed). OTA updates go through `update-service` (Go binary), not dnf. The `rpm` binary is kept explicitly for package queries.

Saves ~46MB on the rootfs.