### PR TITLE
fix(dbc): replace vim-common with vim-tiny

### DIFF
--- a/recipes-fsl/images/librescoot-dbc-image.bb
+++ b/recipes-fsl/images/librescoot-dbc-image.bb
@@ -58,7 +58,7 @@ CORE_IMAGE_EXTRA_INSTALL += " \
     libsqlite3-dev \
     htop \
     iotop \
-    vim-common \
+    vim-tiny \
     tzdata \
     xdelta3 \
     valhalla \


### PR DESCRIPTION
Swaps `vim-common` for `vim-tiny` in the DBC image.

`vim-common` installs syntax highlighting, help files, and runtime support (~17MB). `vim-tiny` provides a functional vi at a fraction of the size. nano is also available.