### PR TITLE
fix(dbc): remove gdb, xdg-user-dirs, libsqlite3-dev

### DIFF
--- a/recipes-fsl/images/librescoot-dbc-image.bb
+++ b/recipes-fsl/images/librescoot-dbc-image.bb
@@ -53,9 +53,7 @@ CORE_IMAGE_EXTRA_INSTALL += " \
     screen \
     chrony \
     chronyc \
-    xdg-user-dirs \
     sqlite3 \
-    libsqlite3-dev \
     htop \
     iotop \
     vim-common \
@@ -67,7 +65,6 @@ CORE_IMAGE_EXTRA_INSTALL += " \
     ffmpeg \
     scootui-qt \
     scootui-tui \
-    gdb \
     glmark2 \
     nano \
 "


### PR DESCRIPTION
Removes three packages that don't belong in the production DBC image:

- `gdb` (7.2MB) - debugger, can be installed ad-hoc when needed
- `xdg-user-dirs` - desktop standard for ~/Documents etc, no use on embedded
- `libsqlite3-dev` (~6MB) - development headers shipped into production

`sqlite3` CLI is kept for diagnostics.