### PR TITLE
feat(mdb): swap boot LED colors to amber kernel, green userland

### DIFF
--- a/recipes-core/boot-led-service/files/librescoot-boot-led.service
+++ b/recipes-core/boot-led-service/files/librescoot-boot-led.service
@@ -6,7 +6,7 @@ Before=sysinit.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/set-dbc-led amber
+ExecStart=/usr/bin/set-dbc-led green
 RemainAfterExit=yes
 
 [Install]

--- a/recipes-kernel/linux/linux-imx/0004-leds-lp5562-init-amber-at-boot.patch
+++ b/recipes-kernel/linux/linux-imx/0004-leds-lp5562-init-amber-at-boot.patch
@@ -1,0 +1,32 @@
+From: Teal Bauer <teal@starsong.eu>
+Date: Mon, 24 Mar 2026 00:00:00 +0100
+Subject: [PATCH] leds: lp5562: initialize LED to amber at boot
+
+The LP5662 was previously initialized to green during driver probe.
+Switch to amber so userland can set green to indicate boot completion.
+
+Upstream-Status: Inappropriate [device-specific]
+
+Signed-off-by: Teal Bauer <teal@starsong.eu>
+---
+ drivers/leds/leds-lp5562.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/leds/leds-lp5562.c b/drivers/leds/leds-lp5562.c
+index 859eacd30f39..fefc27f9eae9 100644
+--- a/drivers/leds/leds-lp5562.c
++++ b/drivers/leds/leds-lp5562.c
+@@ -300,10 +300,10 @@ static int lp5562_post_init_device(struct lp55xx_chip *chip)
+ 	if (ret)
+ 		return ret;
+
+-	/* Initialize all channels PWM to zero -> leds off */
++	/* Initialize LED to amber at boot */
+ 	lp55xx_write(chip, LP5562_REG_R_PWM, 0);
+-	lp55xx_write(chip, LP5562_REG_G_PWM, 255);
+-	lp55xx_write(chip, LP5562_REG_B_PWM, 0);
++	lp55xx_write(chip, LP5562_REG_G_PWM, 0);
++	lp55xx_write(chip, LP5562_REG_B_PWM, 255);
+ 	lp55xx_write(chip, LP5562_REG_W_PWM, 0);
+
+ 	/* Set LED map as register PWM by default */

--- a/recipes-kernel/linux/linux-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-imx_5.4.bb
@@ -27,6 +27,7 @@ SRC_URI = " ${KERNEL_SRC};branch=${SRCBRANCH} \
             file://0001-replace-solaris-style-flag.patch \
             file://0002-ata-ahci-fix-enum-constants-for-gcc-13.patch \
             file://0003-querystatus.patch \
+            file://0004-leds-lp5562-init-amber-at-boot.patch \
           "
 
 SRC_URI:append:unu-mdb = " file://mdb_defconfig"


### PR DESCRIPTION
The lp5562 driver in linux-imx was modified to init the LED green at probe time. The boot-led systemd service then switched to amber once userland started. This meant green = early boot, amber = ready, which is backwards.

Swap them: kernel probe sets amber, boot-led service sets green. Amber now means "booting", green means "userland is up".

- Add kernel patch `0004-leds-lp5562-init-amber-at-boot.patch` (B_PWM=255 instead of G_PWM=255 in `lp5562_post_init_device`)
- Change boot-led service from `set-dbc-led amber` to `set-dbc-led green`