### PR TITLE
feat(dbc): flicker-free Qt rendering via EGLFS fbdev plugin

### DIFF
--- a/recipes-graphics/scootui-qt/files/scootui-qt.service
+++ b/recipes-graphics/scootui-qt/files/scootui-qt.service
@@ -11,9 +11,9 @@ ConditionPathExists=/dev/tty0
 Environment=HOME="/data"
 Environment=XDG_RUNTIME_DIR="/run/user/0"
 Environment=QT_QPA_PLATFORM=eglfs
-Environment=QT_QPA_EGLFS_INTEGRATION=eglfs_kms
-Environment=QT_QPA_EGLFS_KMS_CONFIG=/etc/scootui-qt-kms.json
-Environment=QT_QPA_EGLFS_KMS_ATOMIC=1
+Environment=QT_QPA_EGLFS_INTEGRATION=eglfs_fbdev
+Environment=EGLFS_FBDEV_FB_DEVICE=/dev/fb1
+Environment=EGLFS_FBDEV_RENDER_DEVICE=/dev/dri/renderD128
 Environment=QT_QPA_EGLFS_SWAPINTERVAL=1
 Environment=QSG_RENDER_LOOP=basic
 Environment=QT_PLUGIN_PATH=/usr/plugins:/usr/lib/plugins

--- a/recipes-graphics/scootui-qt/scootui-qt.bb
+++ b/recipes-graphics/scootui-qt/scootui-qt.bb
@@ -43,6 +43,7 @@ RDEPENDS:${PN} = " \
     qtsvg-plugins \
     qtlocation \
     qmaplibre \
+    qt-eglfs-fbdev \
 "
 
 EXTRA_OECMAKE = "-DCMAKE_BUILD_TYPE=Release"

--- a/recipes-graphics/scootui-qt/scootui-qt.bb
+++ b/recipes-graphics/scootui-qt/scootui-qt.bb
@@ -13,7 +13,6 @@ SRCREV = "${SCOOTUI_QT_SRCREV}"
 SRC_URI = "git://github.com/librescoot/scootui-qt.git;branch=${SCOOTUI_QT_BRANCH};protocol=https"
 SRC_URI += "file://scootui-qt.service"
 SRC_URI += "file://scootui-qt-rpi4.service"
-SRC_URI += "file://scootui-qt-kms.json"
 
 PV = "1.0.0+git${SRCPV}"
 PE = "1"
@@ -59,8 +58,6 @@ SYSTEMD_AUTO_ENABLE:${PN} = "disable"
 do_install:append:unu-dbc() {
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/scootui-qt.service ${D}${systemd_system_unitdir}/
-    install -d ${D}${sysconfdir}
-    install -m 0644 ${WORKDIR}/scootui-qt-kms.json ${D}${sysconfdir}/
 }
 
 do_install:append:librescoot-dbc-rpi4() {
@@ -70,6 +67,5 @@ do_install:append:librescoot-dbc-rpi4() {
 
 FILES:${PN} = " \
     ${bindir}/scootui-qt \
-    ${sysconfdir}/scootui-qt-kms.json \
     ${systemd_system_unitdir}/scootui-qt.service \
 "

--- a/recipes-qt/qt6/qt-eglfs-fbdev.bb
+++ b/recipes-qt/qt6/qt-eglfs-fbdev.bb
@@ -1,0 +1,20 @@
+SUMMARY = "Qt EGLFS fbdev device integration plugin"
+DESCRIPTION = "Renders via GPU render node, blits to framebuffer. No DRM modesetting."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "git://github.com/librescoot/qt-eglfs-fbdev.git;branch=main;protocol=https"
+SRCREV = "${AUTOREV}"
+PV = "1.0.0+git${SRCPV}"
+
+S = "${WORKDIR}/git"
+
+inherit cmake qt6-cmake pkgconfig
+
+DEPENDS = " \
+    qtbase \
+    virtual/libgbm \
+    virtual/egl \
+"
+
+FILES:${PN} = "${libdir}/qt6/plugins/egldeviceintegrations/*.so"

--- a/recipes-qt/qt6/qt-eglfs-fbdev.bb
+++ b/recipes-qt/qt6/qt-eglfs-fbdev.bb
@@ -17,4 +17,4 @@ DEPENDS = " \
     virtual/egl \
 "
 
-FILES:${PN} = "${libdir}/qt6/plugins/egldeviceintegrations/*.so"
+FILES:${PN} = "${libdir}/plugins/egldeviceintegrations/*.so"


### PR DESCRIPTION
## Summary

- Add `qt-eglfs-fbdev` recipe and scootui-qt dependency for a custom Qt EGLFS plugin that renders via GPU but blits to a framebuffer device instead of using DRM modesetting
- Switch scootui-qt.service from `eglfs_kms` to `eglfs_fbdev`, targeting `/dev/fb1` (overlay) with renderD128
- Re-add the IPU overlay fbdev kernel patch (`0006-imx-drm-overlay-fbdev-alpha.patch`) that creates `/dev/fb1` with sysfs alpha control

Qt's `eglfs_kms` does a `drmModeSetCrtc()` on every start, causing a visible display flash even though the mode hasn't changed. The fbdev plugin avoids this entirely: EGL renders to a GBM buffer on the GPU render node, `presentBuffer()` converts ARGB8888 to RGB565 and memcpy's to the mmap'd framebuffer. The IPU display timing set at kernel boot is never touched.

Boot sequence: boot-animation on fb0, scootui-qt on fb1 (invisible at alpha=0), hardware crossfade via `imx-overlay-alpha`, then boot-animation stops. Zero flicker from power-on to UI.

Plugin source: https://github.com/librescoot/qt-eglfs-fbdev

## Test plan

- [ ] Build DBC image with these changes
- [ ] Verify `/dev/fb1` exists after boot (overlay kernel patch)
- [ ] Verify scootui-qt starts without display flash
- [ ] Verify boot animation crossfade works (fb0 -> fb1 alpha transition)
- [ ] Verify scootui-qt service restart doesn't flash
- [ ] Test on RPi4 target (should fall back gracefully, no fb1)