### PR TITLE
feat(mdb-netconfig): enable DHCP server on USB0

### DIFF
--- a/recipes-connectivity/mdb-netconfig/files/10-usb0.network
+++ b/recipes-connectivity/mdb-netconfig/files/10-usb0.network
@@ -5,3 +5,10 @@ Name=usb0
 ConfigureWithoutCarrier=yes
 Address=192.168.7.1/24
 LinkLocalAddressing=no
+DHCPServer=yes
+
+[DHCPServer]
+PoolOffset=100
+PoolSize=10
+EmitDNS=no
+EmitRouter=no


### PR DESCRIPTION
## Summary
- Enable systemd-networkd's built-in DHCP server on the MDB's USB0 interface
- Laptops connecting via USB automatically get an IP (192.168.7.100-109) without manual static configuration
- No DNS or default route advertised — keeps it a pure point-to-point link to 192.168.7.x
- DBC's static 192.168.7.2 is unaffected (outside the DHCP pool)

## Test plan
- [x] Tested on live MDB hardware — laptop received 192.168.7.107 via DHCP
- [x] Verified no default route or DNS advertised to client
- [x] Verified SSH to 192.168.7.1 works over DHCP-assigned address
- [x] Verified DBC static IP (192.168.7.2) and existing NAT/forwarding unaffected