### PR TITLE
feat: add mmc-utils to MDB and DBC images

### DIFF
--- a/recipes-fsl/images/librescoot-dbc-image.bb
+++ b/recipes-fsl/images/librescoot-dbc-image.bb
@@ -24,6 +24,7 @@ CORE_IMAGE_EXTRA_INSTALL += " \
     rpm \
     python3 \
     i2c-tools \
+    mmc-utils \
     python3-pyserial \
     python3-systemd \
     python3-dateutil \

--- a/recipes-fsl/images/librescoot-mdb-image.bb
+++ b/recipes-fsl/images/librescoot-mdb-image.bb
@@ -28,6 +28,7 @@ CORE_IMAGE_EXTRA_INSTALL += " \
     python3 \
     canutils \
     i2c-tools \
+    mmc-utils \
     python3-pyserial \
     python3-systemd \
     python3-dateutil \


### PR DESCRIPTION
## Summary

Adds `mmc-utils` to both the MDB and DBC images. update-service
uses `mmc extcsd read` and `mmc bootpart enable` to manage eMMC
boot partition A/B flips when writing U-Boot updates. Companion to
librescoot/update-service#15.

`mmc-utils` is already in poky
(`recipes-devtools/mmc/mmc-utils_git.bb`), so this is just an
`IMAGE_INSTALL` addition. Around 50 KB per image.

Refs librescoot/librescoot#23