### PR TITLE
feat(uboot-env-sync): install A/B watchdog env and bootcmd prefix

### DIFF
--- a/recipes-core/uboot-env-sync/files/uboot-ab-watchdog.conf
+++ b/recipes-core/uboot-env-sync/files/uboot-ab-watchdog.conf
@@ -1,0 +1,14 @@
+# U-Boot A/B watchdog
+#
+# U-Boot increments uboot_ab_bootcount on each boot while uboot_upgrade=1.
+# If the count exceeds uboot_ab_bootlimit, PARTITION_CONFIG is flipped back
+# to uboot_altbootpart via `mmc partconf` and the board resets. On a healthy
+# boot, userspace clears uboot_upgrade so the counter stops growing.
+
+set-if-missing uboot_ab_bootlimit 3
+set-if-missing uboot_ab_bootcount 0
+set-if-missing uboot_upgrade 0
+
+set-if-missing uboot_ab_check if test "${uboot_upgrade}" = "1"; then setexpr uboot_ab_bootcount ${uboot_ab_bootcount} + 1; saveenv; if test ${uboot_ab_bootcount} -gt ${uboot_ab_bootlimit}; then echo "uboot-ab: reverting to boot partition ${uboot_altbootpart}"; mmc partconf ${mender_uboot_dev} ${uboot_altbootpart_ack} ${uboot_altbootpart} 0; setenv uboot_upgrade 0; setenv uboot_ab_bootcount 0; saveenv; reset; fi; fi
+
+set-prepend-if-missing bootcmd run uboot_ab_check;

--- a/recipes-core/uboot-env-sync/files/uboot-env-sync.sh
+++ b/recipes-core/uboot-env-sync/files/uboot-env-sync.sh
@@ -2,11 +2,12 @@
 # Sync U-Boot environment variables from /etc/uboot-env.d/*.conf.
 # Runs on every boot. Supported directives:
 #
-#   set-if-missing key value       — set only if unset or empty
-#   set-always key value           — always overwrite
-#   set-if-matches key old new     — replace old value with new (safe migration)
-#   unset key                      — remove unconditionally
-#   unset-if-matches key value     — remove only if current value matches
+#   set-if-missing key value          set only if unset or empty
+#   set-always key value              always overwrite
+#   set-if-matches key old new        replace old value with new (safe migration)
+#   set-prepend-if-missing key prefix prepend prefix to key if not already present
+#   unset key                         remove unconditionally
+#   unset-if-matches key value        remove only if current value matches
 
 CONF_DIR=/etc/uboot-env.d
 changed=0
@@ -50,6 +51,20 @@ for conf in "$CONF_DIR"/*.conf; do
                     echo "uboot-env-sync: set-if-matches $key: [$oldval] -> [$newval]"
                     changed=1
                 fi
+                ;;
+            set-prepend-if-missing)
+                key="${rest%% *}"
+                prefix="${rest#* }"
+                current="$(fw_printenv -n "$key" 2>/dev/null)" || true
+                case "$current" in
+                    "$prefix"*)
+                        ;;
+                    *)
+                        fw_setenv "$key" "${prefix}${current}"
+                        echo "uboot-env-sync: set-prepend-if-missing $key: prepended [$prefix]"
+                        changed=1
+                        ;;
+                esac
                 ;;
             unset)
                 key="${rest%% *}"

--- a/recipes-core/uboot-env-sync/uboot-env-sync.bb
+++ b/recipes-core/uboot-env-sync/uboot-env-sync.bb
@@ -6,7 +6,8 @@ inherit systemd
 
 SRC_URI = "file://uboot-env-sync.sh \
            file://uboot-env-sync.service \
-           file://identity.conf"
+           file://identity.conf \
+           file://uboot-ab-watchdog.conf"
 SRC_URI:append:unu-dbc = " file://boot-animation.conf"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files/${MACHINE}:"
@@ -25,6 +26,7 @@ do_install() {
 
     install -d ${D}${sysconfdir}/uboot-env.d
     install -m 0644 ${WORKDIR}/identity.conf ${D}${sysconfdir}/uboot-env.d/identity.conf
+    install -m 0644 ${WORKDIR}/uboot-ab-watchdog.conf ${D}${sysconfdir}/uboot-env.d/uboot-ab-watchdog.conf
     if [ -f ${WORKDIR}/boot-animation.conf ]; then
         install -m 0644 ${WORKDIR}/boot-animation.conf ${D}${sysconfdir}/uboot-env.d/boot-animation.conf
     fi


### PR DESCRIPTION
## Summary

Stacked on #37.

Installs the U-Boot side of the A/B watchdog. A `uboot_ab_check`
script in the U-Boot env increments `uboot_ab_bootcount` on each
boot while `uboot_upgrade=1`. When the count exceeds
`uboot_ab_bootlimit` (default 3), it calls
`mmc partconf ${mender_uboot_dev} ${uboot_altbootpart_ack} ${uboot_altbootpart} 0`
to revert `PARTITION_CONFIG`, then resets.

Userspace (update-service, see librescoot/update-service#16) sets
`uboot_upgrade=1` before flipping and clears it on a healthy boot.

## Changes

- `uboot-env-sync.sh`: new `set-prepend-if-missing` directive so
  `bootcmd` can be migrated idempotently without `set-if-matches`
  needing to know the exact old value
- `uboot-ab-watchdog.conf`: installs `uboot_ab_bootlimit=3`,
  `uboot_ab_bootcount=0`, `uboot_upgrade=0` via `set-if-missing`,
  installs the `uboot_ab_check` script, and prepends
  `run uboot_ab_check;` to `bootcmd`

No U-Boot source changes required. Everything runs through
`uboot-env-sync` at boot. `mender_uboot_dev` is already set per
machine by the Mender U-Boot integration (1 on MDB, 2 on DBC).

## Not covered here

- Hardware verification that `mmc partconf` behaves as expected on
  both boards with the 2017.03 NXP U-Boot fork
- U-Boot still has to reach the point of reading env and running
  `bootcmd`. A crash before that is a hard brick

Refs librescoot/librescoot#23