### PR TITLE
feat(dbc): trim multi-user.target tail, drop logind, change boot-animation to Type=exec

### DIFF
--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,4 +1,4 @@
-PACKAGECONFIG:remove:pn-systemd = "timesyncd"
+PACKAGECONFIG:remove:pn-systemd = "timesyncd logind"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 

--- a/recipes-graphics/boot-animation/files/boot-animation.service
+++ b/recipes-graphics/boot-animation/files/boot-animation.service
@@ -8,8 +8,7 @@ ConditionPathExists=/dev/fb0
 [Service]
 ExecStartPre=/bin/sh -c "echo 0 > /sys/class/vtconsole/vtcon1/bind"
 ExecStart=/bin/sh -c 'ANIM=$$(sed -n "s/.*boot\.animation=\([^ ]*\).*/\1/p" /proc/cmdline); ANIM=$${ANIM:-librescoot}; ONCE=""; [ "$$ANIM" = "librescoot" ] && ONCE="--once"; exec /usr/bin/boot-animation /usr/share/boot-animation/$${ANIM}.json --fps 25 --fade-ms 1000 $$ONCE'
-Type=notify
-NotifyAccess=main
+Type=exec
 
 [Install]
 WantedBy=sysinit.target


### PR DESCRIPTION
Two small DBC boot-speedup changes from looking at the on-device boot journal and critical path around multi-user.target.

### Changes

1. systemd: drop logind. Nothing on DBC uses it: no interactive logins (SSH only), no seat tracking, pam_systemd is marked \`optional\` in the PAM config so dropbear is unaffected. Its 1.7s start parallels chrony and backlight at the tail of multi-user.target, so this shortens the slowest-unit time at that stage.
2. boot-animation: Type=notify to Type=exec. No unit is ordered After=boot-animation.service, so the notify semantics only added blocking. \`Before=multi-user.target\` + \`Type=notify\` made multi-user wait for \`READY=1\`, which the binary sends after its first full render loop (~2s). With \`Type=exec\`, multi-user just waits for exec() to return.

Two independent commits so either can be reverted on its own if something regresses.

### Test plan
Tested on deep-blue DBC with a custom-nightly build of the integration branch.

- [x] Build image, deploy to DBC
- [x] \`journalctl -b 0 -o short-monotonic | grep -E 'Reached target|Started User Login|Started Boot Animation'\`: multi-user.target arrives earlier (13.02s → 11.74s on steady-state 2nd boot), Boot Animation \"Started\" fires in 140ms at exec-time (was 2.37s after first loop)
- [x] SSH via dropbear still works (verified throughout the session; \`systemd-logind.service: unit not found\`)
- [x] Animation still renders and fades out as before (visible from 3.41s to 15.66s, \`Consumed 3.56s CPU time\` vs 3.94s before)

Total boot time: 13.38s → 12.19s (-1.19s) on steady-state boot.