### PR TITLE
feat(mdb-dt): add wakeup-capable gpio-keys entry for BMX055 INT1

### DIFF
--- a/recipes-kernel/linux/linux-imx/librescoot-mdb.dts
+++ b/recipes-kernel/linux/linux-imx/librescoot-mdb.dts
@@ -1599,5 +1599,13 @@
 			gpios = <0x39 0x1c 0x00>;
 			debounce-interval = <0x1e>;
 		};
+
+		accel_int1 {
+			label = "GPIO Key ACC_INT1";
+			linux,code = <0x2b>;
+			gpios = <0x39 0x16 0x00>;
+			debounce-interval = <0x01>;
+			wakeup-source;
+		};
 	};
 };


### PR DESCRIPTION
Route the accelerometer INT1 line (`LCD_DATA17` / `GPIO3_IO22` / `gpiochip2` line 22 / sysfs `gpio-86`) through the `gpio-keys` driver so it surfaces to userspace as keycode `0x2b` and can wake the system from suspend via the `wakeup-source;` mechanism — same pattern the brake levers already use.

## Why

alarm-service currently polls the BMX055 motion-interrupt status register every 100 ms. The hardware INT1 line is physically wired but not consumed by any kernel driver, so the system can neither react with zero latency nor wake from suspend on motion. With this entry landed, alarm-service can switch to an evdev reader on `/dev/input/by-path/platform-gpio-keys-event` and pick up both benefits in one change.

## Pinctrl detail

The pad is already muxed as GPIO input with a 47 kΩ pull-up and hysteresis via the `iomuxc` hog (`pinctrl-0 = <&hoggrp-1>` on the iomuxc node, which includes `0x15c 0x3e8 ... 0x17059`). Adding `LCD_DATA17` to `gpio_keysgrp` *as well* causes pinctrl to refuse the probe (`pin MX6UL_PAD_LCD_DATA17 already requested by 20e0000.iomuxc; cannot claim for gpio-keys`) — tried that first, rolled it back. Only the child node is needed.

## Verified on target

```
# cat /sys/devices/soc0/gpio-keys/keys
16,18-20,23-25,30-38,43,46,48-50

# awk '/gpiochip2:/,/gpiochip3:/' /sys/kernel/debug/gpio | grep gpio-86
gpio-86  (                    |GPIO Key ACC_INT1   ) in  lo IRQ

# grep ACC_INT1 /proc/interrupts
156:   2  gpio-mxc  22  Edge  GPIO Key ACC_INT1

# grep gpio-keys /sys/kernel/debug/wakeup_sources
gpio-keys       0       0       0       0       ...
```

## Follow-up

alarm-service PR will switch to evdev, drop the `go-gpiocdev` probe from #4, and reduce the poller tick to a 1 s watchdog.