### PR TITLE
fix(dbc): make etnaviv autosuspend rule actually match hardware

### DIFF
--- a/recipes-core/systemd/systemd/99-etnaviv-no-autosuspend.rules
+++ b/recipes-core/systemd/systemd/99-etnaviv-no-autosuspend.rules
@@ -1,3 +1,8 @@
 # Disable runtime PM autosuspend for etnaviv GPU to prevent intermittent
 # display dropouts caused by GPU suspend/resume latency exceeding vblank.
-ACTION=="add", SUBSYSTEM=="drm", DRIVERS=="etnaviv", ATTR{power/control}="on"
+#
+# The etnaviv GPUs live on the platform bus (imx6sx-gpu-subsystem), not the
+# drm bus — drm devices are the /dev/dri/cardN character devices, which
+# don't have their own power/control knob. The kernel's PM core tracks
+# autosuspend at the platform-device level, so that's what we match.
+ACTION=="add", SUBSYSTEM=="platform", DRIVER=="etnaviv-gpu", ATTR{power/control}="on"


### PR DESCRIPTION
Follow-up from #40. When the rule finally got installed on a running DBC (it had been dead code under the eudev bbappend for a long time), it turned out to not match any hardware: `SUBSYSTEM=="drm", DRIVERS=="etnaviv"` picks nothing because the etnaviv GPUs on iMX6 live on the platform bus under driver `etnaviv-gpu`. The drm subsystem only has the `/dev/dri/cardN` character devices, which don't expose `power/control` to udev.

Checked on deep-blue after #40 landed:

```
# udevadm info --attribute-walk /sys/bus/platform/devices/130000.gpu
    SUBSYSTEM=="platform"
    DRIVER=="etnaviv-gpu"
    ...

# cat /sys/bus/platform/devices/130000.gpu/power/control
auto
```

Rule installed but never fires, so autosuspend is still enabled, so the display-flicker symptom the rule was meant to prevent is also still present.

Fix: match `SUBSYSTEM=="platform", DRIVER=="etnaviv-gpu"` — the PM core tracks runtime PM at that level. Both GPUs (GC880 at 130000.gpu, GC320 at 134000.gpu) match.

### Test plan
- [ ] Build, deploy to DBC
- [ ] `cat /sys/bus/platform/devices/130000.gpu/power/control` reports `on` (not `auto`) after boot
- [ ] Same for 134000.gpu
- [ ] No regression in display output / flicker observed under normal use