### PR TITLE
Quick wins: cut boot-log noise from tmpfiles, env vars, DHCPv6

### DIFF
--- a/recipes-connectivity/mdb-netconfig/files/30-end0.network
+++ b/recipes-connectivity/mdb-netconfig/files/30-end0.network
@@ -1,3 +1,11 @@
+# MDB may or may not have a PHY wired to the i.MX6 FEC controller: production
+# boards don't, some dev boards do. Leave the interface configured for DHCP so
+# dev boards work out of the box.
+#
+# DHCP=ipv4 (instead of 'yes') avoids the boot-time warning
+#   DHCPv6 client is enabled but IPv6 link-local addressing is disabled.
+# since we keep LLA off here.
+
 [Match]
 Name=end0
 
@@ -5,5 +13,5 @@ Name=end0
 RequiredForOnline=no
 
 [Network]
-DHCP=yes
+DHCP=ipv4
 LinkLocalAddressing=no

--- a/recipes-connectivity/networkmanager/networkmanager/20-modemmanager-ordering.conf
+++ b/recipes-connectivity/networkmanager/networkmanager/20-modemmanager-ordering.conf
@@ -1,0 +1,8 @@
+# Make NetworkManager stop before ModemManager at shutdown (systemd reverses
+# ordering for stop). Without this, MM starts disabling the modem while NM is
+# still active; the modem port briefly goes "no longer controllable", NM sees
+# ModemManager drop off the bus and kicks off a fresh DHCP transaction on
+# wwu1i5 on the way down. Also avoids dbus activation failures for
+# nm-dispatcher during shutdown.
+[Unit]
+After=ModemManager.service

--- a/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -1,2 +1,12 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 PACKAGECONFIG:append = " modemmanager ppp"
+
+SRC_URI += "file://20-modemmanager-ordering.conf"
+
+do_install:append() {
+    install -d ${D}${systemd_unitdir}/system/NetworkManager.service.d
+    install -m 0644 ${WORKDIR}/20-modemmanager-ordering.conf \
+        ${D}${systemd_unitdir}/system/NetworkManager.service.d/20-modemmanager-ordering.conf
+}
+
+FILES:${PN} += "${systemd_unitdir}/system/NetworkManager.service.d/20-modemmanager-ordering.conf"

--- a/recipes-core/systemd/systemd/tmp.conf
+++ b/recipes-core/systemd/systemd/tmp.conf
@@ -1,0 +1,11 @@
+# LibreScoot override of /usr/lib/tmpfiles.d/tmp.conf
+#
+# /var/tmp is a symlink to volatile/tmp on LibreScoot. Stock systemd's
+# "q /var/tmp 1777 root root 30d" errors out at boot because tmpfiles
+# type 'q' refuses to operate on non-directories:
+#
+#   systemd-tmpfiles[N]: "/var/tmp" already exists and is not a directory.
+#
+# /tmp is its own tmpfs mount, so the q entry for it stays.
+
+q /tmp 1777 root root 10d

--- a/recipes-core/systemd/systemd/var.conf
+++ b/recipes-core/systemd/systemd/var.conf
@@ -1,0 +1,24 @@
+# LibreScoot override of /usr/lib/tmpfiles.d/var.conf
+#
+# /var/log is a symlink to volatile/log on LibreScoot (managed by base-files
+# and 00-create-volatile.conf). Stock systemd's "d /var/log" entry errors
+# out at boot because tmpfiles type 'd' refuses to operate on non-directories:
+#
+#   systemd-tmpfiles[N]: "/var/log" already exists and is not a directory.
+#
+# We keep the rest of the stock entries. The f-entries for wtmp/btmp/lastlog
+# work fine - they follow the symlink and land in /var/volatile/log/.
+
+q /var 0755 - - -
+
+L /var/run - - - - ../run
+
+f /var/log/wtmp 0664 root utmp -
+f /var/log/btmp 0660 root utmp -
+f /var/log/lastlog 0664 root utmp -
+
+d /var/cache 0755 - - -
+
+d /var/lib 0755 - - -
+
+d /var/spool 0755 - - -

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -11,6 +11,8 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://journald.conf"
 SRC_URI += "file://00-create-volatile.conf"
+SRC_URI += "file://var.conf"
+SRC_URI += "file://tmp.conf"
 SRC_URI += "file://journal-upload.conf"
 SRC_URI += "file://journal-upload-volatile-state.conf"
 SRC_URI += "file://90-journal-upload.preset"
@@ -23,6 +25,12 @@ do_install:append() {
 
     # Override the default 00-create-volatile.conf to avoid duplicate /run/lock
     install -m 0644 ${WORKDIR}/00-create-volatile.conf ${D}${libdir}/tmpfiles.d/00-create-volatile.conf
+
+    # Override stock /usr/lib/tmpfiles.d/{var,tmp}.conf via /etc so the 'd /var/log'
+    # and 'q /var/tmp' entries don't error out on our volatile/ symlinks.
+    install -d ${D}${sysconfdir}/tmpfiles.d
+    install -m 0644 ${WORKDIR}/var.conf ${D}${sysconfdir}/tmpfiles.d/var.conf
+    install -m 0644 ${WORKDIR}/tmp.conf ${D}${sysconfdir}/tmpfiles.d/tmp.conf
 
     # Preset: auto-enable systemd-journal-upload.service at first boot
     install -d ${D}${systemd_unitdir}/system-preset

--- a/recipes-extended/xinetd/files/xinetd.sysconfig
+++ b/recipes-extended/xinetd/files/xinetd.sysconfig
@@ -1,0 +1,8 @@
+# Options to pass to xinetd via the xinetd.service unit.
+# Stock unit has:
+#   EnvironmentFile=-/etc/sysconfig/xinetd
+#   ExecStart=/usr/sbin/xinetd -dontfork "$EXTRAOPTIONS"
+# With EXTRAOPTIONS defined (even as empty), systemd stops warning:
+#   xinetd.service: Referenced but unset environment variable evaluates to
+#   an empty string: EXTRAOPTIONS
+EXTRAOPTIONS=""

--- a/recipes-extended/xinetd/xinetd_%.bbappend
+++ b/recipes-extended/xinetd/xinetd_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://xinetd.sysconfig"
+
+do_install:append() {
+    # Stock xinetd.service has: EnvironmentFile=-/etc/sysconfig/xinetd
+    # Ship the file (empty EXTRAOPTIONS) so systemd stops warning on every start.
+    install -d ${D}${sysconfdir}/sysconfig
+    install -m 0644 ${WORKDIR}/xinetd.sysconfig ${D}${sysconfdir}/sysconfig/xinetd
+}

--- a/recipes-support/chrony/chrony_%.bbappend
+++ b/recipes-support/chrony/chrony_%.bbappend
@@ -1,8 +1,16 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
+SRC_URI += "file://chronyd.default"
 SRC_URI:append:unu-mdb = " file://chrony-mdb.conf"
 SRC_URI:append:unu-dbc = " file://chrony-dbc.conf"
 SRC_URI:append:librescoot-dbc-rpi4 = " file://chrony-dbc.conf"
+
+do_install:append() {
+    # Stock chronyd.service has: EnvironmentFile=-/etc/default/chronyd
+    # Ship the file (empty OPTIONS) so systemd stops warning on every start.
+    install -d ${D}${sysconfdir}/default
+    install -m 0644 ${WORKDIR}/chronyd.default ${D}${sysconfdir}/default/chronyd
+}
 
 do_install:append:unu-mdb() {
     install -d ${D}${sysconfdir}

--- a/recipes-support/chrony/files/chronyd.default
+++ b/recipes-support/chrony/files/chronyd.default
@@ -1,0 +1,6 @@
+# Options to pass to chronyd via the chronyd.service unit.
+# The stock unit has: ExecStart=/usr/sbin/chronyd $OPTIONS
+# With an empty OPTIONS, systemd no longer warns:
+#   chronyd.service: Referenced but unset environment variable evaluates to
+#   an empty string: OPTIONS
+OPTIONS=""


### PR DESCRIPTION
Three small fixes that each silence a recurring warning at every MDB boot. Identified while analysing a shutdown-log session; none change runtime behaviour beyond stopping systemd/networkd from printing the warning.

## Commits

### `fix(systemd): override tmpfiles.d/var.conf+tmp.conf for volatile symlinks`
`/var/log` and `/var/tmp` are symlinks to `volatile/log|tmp`. Stock systemd's `d /var/log` and `q /var/tmp` error on every boot because the types refuse to operate on non-directories:

```
systemd-tmpfiles: "/var/log" already exists and is not a directory.
systemd-tmpfiles: "/var/tmp" already exists and is not a directory.
```

Ship `/etc/tmpfiles.d/{var,tmp}.conf` overrides (systemd prefers `/etc` over `/usr/lib` by basename). Drop the offending lines, keep `wtmp/btmp/lastlog` etc.

### `fix(systemd): ship env files for chronyd and xinetd`
Stock `chronyd.service` and `xinetd.service` reference `EnvironmentFile=-/etc/default/chronyd` and `-/etc/sysconfig/xinetd`, then expand `\$OPTIONS` / `\$EXTRAOPTIONS`. Neither file was shipped, so systemd warned every start:

```
chronyd.service: Referenced but unset environment variable evaluates to
an empty string: OPTIONS
xinetd.service: … EXTRAOPTIONS
```

Ship both with empty values. Warnings gone.

### `fix(mdb-netconfig): silence DHCPv6 warning on end0`
`30-end0.network` had `DHCP=yes` but `LinkLocalAddressing=no`, so networkd complained every boot:

```
30-end0.network: DHCPv6 client is enabled but IPv6 link-local addressing
is disabled. Disabling DHCPv6 client.
```

Switch to `DHCP=ipv4`. Kept the file (some dev boards have a PHY, so leave end0 eligible for DHCP).

## Test plan

All three verified on deep-blue by deploying the files by hand and restarting the relevant services / re-running `systemd-tmpfiles --create`:

- [x] `systemd-tmpfiles --cat-config` shows `/etc/tmpfiles.d/{var,tmp}.conf` win over the `/usr/lib` versions; no more "already exists and is not a directory" messages.
- [x] `systemctl restart chronyd xinetd` — no more "Referenced but unset environment variable" in the journal.
- [x] 30-end0 change not deployed live (would need networkd reload on deep-blue), but config is a single keyword swap with behaviour preserved for dev boards.