### PR TITLE
fix(vim-tiny): ship minimal defaults.vim to silence E1187

### DIFF
--- a/recipes-support/vim/files/defaults.vim
+++ b/recipes-support/vim/files/defaults.vim
@@ -1,0 +1,9 @@
+set backspace=indent,eol,start
+set history=200
+set ruler
+set showcmd
+set wildmenu
+set incsearch
+set autoindent
+set ttimeout ttimeoutlen=100
+set scrolloff=5

--- a/recipes-support/vim/vim-tiny_%.bbappend
+++ b/recipes-support/vim/vim-tiny_%.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://defaults.vim"
+
+do_install:append() {
+    install -D -m 0644 ${WORKDIR}/defaults.vim ${D}${datadir}/vim/${VIMDIR}/defaults.vim
+}


### PR DESCRIPTION
## Summary

- vim 9.1 includes `FEAT_EVAL` even in `--with-features=tiny` builds, so startup always tries to source `defaults.vim` when no vimrc is present
- `defaults.vim` lives in `vim-common`, which was dropped in #31 for size reasons (~17MB)
- Adds a `vim-tiny_%.bbappend` that installs a stripped-down `defaults.vim` into the right `$VIMRUNTIME` path — no vim-common needed

## Test plan

- [ ] Build DBC image and verify `vim /some/file` opens without `E1187: Failed to source defaults.vim`