### PR TITLE
chore(pn544): silence per-boot kernel log spam

### DIFF
--- a/recipes-kernel/linux/linux-fslc/librescoot-mdb.dts
+++ b/recipes-kernel/linux/linux-fslc/librescoot-mdb.dts
@@ -1126,6 +1126,10 @@
 					clock-frequency = <0x186a0>;
 					interrupt-gpios = <0x2e 0x10 0x00>;
 					enable-gpios = <0x2d 0x0a 0x01>;
+					nxp,pn54x-vbat-supply = <0x3e>;
+					nxp,pn54x-sevdd-supply = <0x3e>;
+					nxp,pn54x-pvdd-supply = <0x3e>;
+					nxp,pn54x-pmuvcc-supply = <0x3e>;
 				};
 			};
 
@@ -1150,6 +1154,10 @@
 					clock-frequency = <0x186a0>;
 					interrupt-gpios = <0x2e 0x11 0x00>;
 					enable-gpios = <0x31 0x00 0x01>;
+					nxp,pn54x-vbat-supply = <0x3e>;
+					nxp,pn54x-sevdd-supply = <0x3e>;
+					nxp,pn54x-pvdd-supply = <0x3e>;
+					nxp,pn54x-pmuvcc-supply = <0x3e>;
 				};
 			};
 
@@ -1175,6 +1183,10 @@
 					interrupt-gpios = <0x2d 0x02 0x00>;
 					enable-gpios = <0x31 0x01 0x01>;
 					wakeup-source;
+					nxp,pn54x-vbat-supply = <0x3e>;
+					nxp,pn54x-sevdd-supply = <0x3e>;
+					nxp,pn54x-pvdd-supply = <0x3e>;
+					nxp,pn54x-pmuvcc-supply = <0x3e>;
 				};
 
 				lp5562@30 {
@@ -1450,6 +1462,13 @@
 			regulator-min-microvolt = <0x325aa0>;
 			regulator-max-microvolt = <0x325aa0>;
 			phandle = <0x2a>;
+		};
+
+		regulator@2 {
+			compatible = "regulator-fixed";
+			regulator-name = "pn547-supply";
+			regulator-always-on;
+			phandle = <0x3e>;
 		};
 	};
 

--- a/recipes-kernel/linux/linux-imx/0005-pn5xx-demote-optional-gpio-warnings-to-debug.patch
+++ b/recipes-kernel/linux/linux-imx/0005-pn5xx-demote-optional-gpio-warnings-to-debug.patch
@@ -1,0 +1,41 @@
+From: Teal Bauer <teal@starsong.eu>
+Date: Sat, 25 Apr 2026 00:00:00 +0200
+Subject: [PATCH] nfc: pn5xx: demote optional FIRM/CLKREQ GPIO warnings to debug
+
+The PN7150 NFC controllers used on this board do not wire up the
+firmware-download or clock-request GPIOs. The driver correctly treats
+both as optional and falls back to GPIO_UNUSED, but it still logs a
+dev_warn for each missing pin on every probe. With three NFC chips
+that's six warning lines on every boot — pure noise.
+
+Drop them to dev_dbg so they only appear when explicitly debugging.
+
+Upstream-Status: Inappropriate [embedded-specific log noise reduction]
+
+Signed-off-by: Teal Bauer <teal@starsong.eu>
+---
+ drivers/nfc/pn5xx/pn5xx_i2c.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/nfc/pn5xx/pn5xx_i2c.c b/drivers/nfc/pn5xx/pn5xx_i2c.c
+index 4cc510f73a99..26cb3dc5cd18 100755
+--- a/drivers/nfc/pn5xx/pn5xx_i2c.c
++++ b/drivers/nfc/pn5xx/pn5xx_i2c.c
+@@ -506,7 +506,7 @@ static int pn54x_get_pdata(struct device *dev,
+ 	}
+ 	else {
+ 		pdata->firm_gpio = GPIO_UNUSED;
+-		dev_warn(dev, "FIRM GPIO <OPTIONAL> error getting from OF node\n");
++		dev_dbg(dev, "FIRM GPIO <OPTIONAL> error getting from OF node\n");
+ 	}
+ 
+ 	/* irq pin - data available irq - REQUIRED */
+@@ -529,7 +529,7 @@ static int pn54x_get_pdata(struct device *dev,
+ 	}
+ 	else {
+ 		pdata->clkreq_gpio = GPIO_UNUSED;
+-		dev_warn(dev, "CLKREQ GPIO <OPTIONAL> error getting from OF node\n");
++		dev_dbg(dev, "CLKREQ GPIO <OPTIONAL> error getting from OF node\n");
+ 	}
+ 
+ 	/* handle the regulator lines - these are optional

--- a/recipes-kernel/linux/linux-imx/librescoot-mdb.dts
+++ b/recipes-kernel/linux/linux-imx/librescoot-mdb.dts
@@ -1126,6 +1126,10 @@
 					clock-frequency = <0x186a0>;
 					interrupt-gpios = <0x2e 0x10 0x00>;
 					enable-gpios = <0x2d 0x0a 0x01>;
+					nxp,pn54x-vbat-supply = <0x3e>;
+					nxp,pn54x-sevdd-supply = <0x3e>;
+					nxp,pn54x-pvdd-supply = <0x3e>;
+					nxp,pn54x-pmuvcc-supply = <0x3e>;
 				};
 			};
 
@@ -1150,6 +1154,10 @@
 					clock-frequency = <0x186a0>;
 					interrupt-gpios = <0x2e 0x11 0x00>;
 					enable-gpios = <0x31 0x00 0x01>;
+					nxp,pn54x-vbat-supply = <0x3e>;
+					nxp,pn54x-sevdd-supply = <0x3e>;
+					nxp,pn54x-pvdd-supply = <0x3e>;
+					nxp,pn54x-pmuvcc-supply = <0x3e>;
 				};
 			};
 
@@ -1175,6 +1183,10 @@
 					interrupt-gpios = <0x2d 0x02 0x00>;
 					enable-gpios = <0x31 0x01 0x01>;
 					wakeup-source;
+					nxp,pn54x-vbat-supply = <0x3e>;
+					nxp,pn54x-sevdd-supply = <0x3e>;
+					nxp,pn54x-pvdd-supply = <0x3e>;
+					nxp,pn54x-pmuvcc-supply = <0x3e>;
 				};
 
 				lp5562@30 {
@@ -1463,6 +1475,13 @@
 			regulator-min-microvolt = <0x325aa0>;
 			regulator-max-microvolt = <0x325aa0>;
 			phandle = <0x2a>;
+		};
+
+		regulator@2 {
+			compatible = "regulator-fixed";
+			regulator-name = "pn547-supply";
+			regulator-always-on;
+			phandle = <0x3e>;
 		};
 	};
 

--- a/recipes-kernel/linux/linux-imx_5.4.bb
+++ b/recipes-kernel/linux/linux-imx_5.4.bb
@@ -28,6 +28,7 @@ SRC_URI = " ${KERNEL_SRC};branch=${SRCBRANCH} \
             file://0002-ata-ahci-fix-enum-constants-for-gcc-13.patch \
             file://0003-querystatus.patch \
             file://0004-leds-lp5562-init-amber-at-boot.patch \
+            file://0005-pn5xx-demote-optional-gpio-warnings-to-debug.patch \
           "
 
 SRC_URI:append:unu-mdb = " file://mdb_defconfig"


### PR DESCRIPTION
## Summary

Two small fixes to silence ~18 lines of per-boot kernel noise from the three PN7150 NFC controllers on the MDB.

### Part 1 — DT supplies
Each PN7150 chip currently triggers four `supply nxp,pn54x-X not found, using dummy regulator` lines because the driver looks up named regulators that we never declared. The chips are fed from a single 3V3 rail, not the four named NXP supplies. Adds an `always-on` `regulator-fixed` dummy and references it from each `pn547@...` node via the four `nxp,pn54x-*-supply` phandles (`vbat`, `sevdd`, `pvdd`, `pmuvcc`). Applied to both kernel trees (`linux-imx` 5.4 and `linux-fslc` 6.6) for parity.

### Part 2 — Driver patch
The out-of-tree `pn5xx` driver in our `linux-imx` fork emits a `dev_warn` for the optional `firmware-gpios` and `nxp,pn54x-clkreq` GPIOs whenever they aren't wired in DT. Our boards don't use either pin, so each chip prints two warnings per boot. Demotes both to `dev_dbg`. Only applies to `linux-imx` (the MDB kernel) — the `linux-fslc` tree doesn't carry this driver.

Net effect: the 18-line PN7150 wall on every boot goes away. NFC functionality unchanged.

## Test plan

- [x] DT compiles cleanly with `dtc -I dts -O dtb` on both files (warnings present in baseline persist; no new errors).
- [x] Decompiled DTB shows the `nxp,pn54x-*-supply` phandles resolve to the new `pn547-supply` regulator node.
- [x] `git apply --check` succeeds for `0005-pn5xx-demote-optional-gpio-warnings-to-debug.patch` against `linux-imx` SRCREV `8115d570b280`.
- [ ] Yocto rebuild of `linux-imx` (and `librescoot-mdb.dtb` regen) succeeds — **not run in this session**.
- [ ] On-target boot on Deep-Blue: confirm the 12 supply lines and 6 GPIO warnings are gone; confirm NFC reads/writes still work end-to-end (`battery-service` boots happy, can talk to all three slots).
- [ ] No new boot-time regressions in `dmesg` (regulator core, NFC subsystem).

## Notes

- New phandle is `0x3e` in both DTS files (highest existing phandle was `0x3d`); decompile confirms no collision.
- The patch carries an `Upstream-Status: Inappropriate` header per Scarthgap QA requirements — the messages might be useful upstream as `dev_dbg`, but submitting that to NXP's out-of-tree driver is not realistic.