### PR TITLE
chore: standardize Librescoot spelling in user-visible text

### DIFF
--- a/classes/librescoot-go.bbclass
+++ b/classes/librescoot-go.bbclass
@@ -1,4 +1,4 @@
-# Class for LibreScoot Go services - versioning from git tags
+# Class for Librescoot Go services - versioning from git tags
 #
 # This class injects version information from git tags into Go binaries
 # via ldflags, similar to what the Makefile does with:

--- a/conf/distro/librescoot-dbc.conf
+++ b/conf/distro/librescoot-dbc.conf
@@ -3,7 +3,7 @@ include conf/distro/include/fsl-imx-preferred-env.inc
 
 DISTRO = "librescoot-dbc"
 
-DISTRO_NAME = "LibreScoot"
+DISTRO_NAME = "Librescoot"
 DISTRO_CODENAME ?= "none"
 
 DISTRO_FEATURES:remove = "directfb x11 zeroconf avahi 3g nfc bluetooth"

--- a/conf/distro/librescoot-mdb.conf
+++ b/conf/distro/librescoot-mdb.conf
@@ -3,7 +3,7 @@ include conf/distro/include/fsl-imx-preferred-env.inc
 
 DISTRO = "librescoot-mdb"
 
-DISTRO_NAME = "LibreScoot"
+DISTRO_NAME = "Librescoot"
 DISTRO_CODENAME ?= "none"
 
 DISTRO_FEATURES:remove = "directfb x11 wayland zeroconf avahi"

--- a/recipes-connectivity/dbc-netconfig/files/librescoot-netconfig.service
+++ b/recipes-connectivity/dbc-netconfig/files/librescoot-netconfig.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=LibreScoot network configuration script
+Description=Librescoot network configuration script
 Wants=local-fs.target
 After=local-fs.target
 

--- a/recipes-connectivity/mdb-netconfig/files/librescoot-netconfig.service
+++ b/recipes-connectivity/mdb-netconfig/files/librescoot-netconfig.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=LibreScoot network configuration script
+Description=Librescoot network configuration script
 Wants=local-fs.target
 After=local-fs.target
 

--- a/recipes-core/alarm-service/alarm-service.bb
+++ b/recipes-core/alarm-service/alarm-service.bb
@@ -1,4 +1,4 @@
-SUMMARY = "LibreScoot Alarm Service"
+SUMMARY = "Librescoot Alarm Service"
 HOMEPAGE = "https://github.com/librescoot/alarm-service"
 LICENSE = "CC-BY-NC-4.0"
 LIC_FILES_CHKSUM = "file://src/alarm-service/LICENSE;md5=fb5d051e53001fdff7fec0f368f47190"

--- a/recipes-core/alarm-service/files/librescoot-alarm.service
+++ b/recipes-core/alarm-service/files/librescoot-alarm.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=LibreScoot Alarm Service
+Description=Librescoot Alarm Service
 After=redis.service librescoot-vehicle.service librescoot-settings.service
 Wants=redis.service
 

--- a/recipes-core/base-files/files/librescoot-dbc-rpi4/hosts
+++ b/recipes-core/base-files/files/librescoot-dbc-rpi4/hosts
@@ -7,5 +7,5 @@ ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 
-# LibreScoot hostname alias
+# Librescoot hostname alias
 192.168.7.1	mdb

--- a/recipes-core/base-files/files/unu-dbc/hosts
+++ b/recipes-core/base-files/files/unu-dbc/hosts
@@ -7,5 +7,5 @@ ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 
-# LibreScoot hostname alias
+# Librescoot hostname alias
 192.168.7.1	mdb

--- a/recipes-core/base-files/files/unu-mdb/hosts
+++ b/recipes-core/base-files/files/unu-mdb/hosts
@@ -7,5 +7,5 @@ ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 
-# LibreScoot hostname alias
+# Librescoot hostname alias
 192.168.7.2	dbc

--- a/recipes-core/battery-service/battery-service.bb
+++ b/recipes-core/battery-service/battery-service.bb
@@ -1,4 +1,4 @@
-SUMMARY = "LibreScoot Battery Service"
+SUMMARY = "Librescoot Battery Service"
 HOMEPAGE = "https://github.com/librescoot/battery-service"
 LICENSE = "CC-BY-NC-SA-4.0"
 LIC_FILES_CHKSUM = "file://src/battery-service/LICENSE;md5=fb5d051e53001fdff7fec0f368f47190"

--- a/recipes-core/bluetooth-service/bluetooth-service.bb
+++ b/recipes-core/bluetooth-service/bluetooth-service.bb
@@ -1,4 +1,4 @@
-SUMMARY = "LibreScoot Bluetooth Service"
+SUMMARY = "Librescoot Bluetooth Service"
 HOMEPAGE = "https://github.com/librescoot/bluetooth-service"
 LICENSE = "CC-BY-NC-SA-4.0"
 LIC_FILES_CHKSUM = "file://src/github.com/librescoot/bluetooth-service/LICENSE;md5=fb5d051e53001fdff7fec0f368f47190"

--- a/recipes-core/boot-led-service/files/librescoot-boot-led.service
+++ b/recipes-core/boot-led-service/files/librescoot-boot-led.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=LibreScoot Boot LED Service
+Description=Librescoot Boot LED Service
 DefaultDependencies=no
 After=systemd-modules-load.service
 Before=sysinit.target

--- a/recipes-core/data-server/data-server.bb
+++ b/recipes-core/data-server/data-server.bb
@@ -1,4 +1,4 @@
-SUMMARY = "LibreScoot Data Server"
+SUMMARY = "Librescoot Data Server"
 HOMEPAGE = "https://github.com/librescoot/data-server"
 LICENSE = "AGPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://src/data-server/LICENSE;md5=eb1e647870add0502f8f010b19de32af"

--- a/recipes-core/data-server/files/librescoot-data-server.service
+++ b/recipes-core/data-server/files/librescoot-data-server.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=LibreScoot Data Server
+Description=Librescoot Data Server
 After=local-fs.target
 
 [Service]

--- a/recipes-core/dbc-backlight-service/dbc-backlight-service.bb
+++ b/recipes-core/dbc-backlight-service/dbc-backlight-service.bb
@@ -1,4 +1,4 @@
-SUMMARY = "LibreScoot Dashboard Controller Backlight Service"
+SUMMARY = "Librescoot Dashboard Controller Backlight Service"
 HOMEPAGE = "https://github.com/librescoot/dbc-backlight-service"
 LICENSE = "CC-BY-NC-SA-4.0"
 LIC_FILES_CHKSUM = "file://src/github.com/librescoot/dbc-backlight-service/LICENSE;md5=136c671dba2d2f644b882e31c3e289e8"

--- a/recipes-core/ecu-service/ecu-service.bb
+++ b/recipes-core/ecu-service/ecu-service.bb
@@ -1,4 +1,4 @@
-SUMMARY = "LibreScoot ECU Service"
+SUMMARY = "Librescoot ECU Service"
 HOMEPAGE = "https://github.com/librescoot/ecu-service"
 LICENSE = "CC-BY-NC-SA-4.0"
 LIC_FILES_CHKSUM = "file://src/ecu-service/LICENSE;md5=fb5d051e53001fdff7fec0f368f47190"

--- a/recipes-core/keycard-service/files/librescoot-keycard.service
+++ b/recipes-core/keycard-service/files/librescoot-keycard.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=LibreScoot Keycard Service
+Description=Librescoot Keycard Service
 Requires=redis.service
 After=redis.service
 After=librescoot-vehicle.service

--- a/recipes-core/keycard-service/keycard-service.bb
+++ b/recipes-core/keycard-service/keycard-service.bb
@@ -1,4 +1,4 @@
-SUMMARY = "LibreScoot Keycard Service"
+SUMMARY = "Librescoot Keycard Service"
 HOMEPAGE = "https://github.com/librescoot/keycard-service"
 LICENSE = "CC-BY-NC-4.0"
 LIC_FILES_CHKSUM = "file://src/keycard-service/LICENSE;md5=fb5d051e53001fdff7fec0f368f47190"

--- a/recipes-core/lsc/lsc.bb
+++ b/recipes-core/lsc/lsc.bb
@@ -1,4 +1,4 @@
-SUMMARY = "LibreScoot Control CLI"
+SUMMARY = "Librescoot Control CLI"
 HOMEPAGE = "https://github.com/librescoot/lsc"
 LICENSE = "CC-BY-NC-4.0"
 LIC_FILES_CHKSUM = "file://src/lsc/LICENSE;md5=fb5d051e53001fdff7fec0f368f47190"

--- a/recipes-core/modem-service/files/librescoot-modem.service
+++ b/recipes-core/modem-service/files/librescoot-modem.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=LibreScoot Modem Service
+Description=Librescoot Modem Service
 Requires=redis.service
 After=redis.service dbus.service ModemManager.service
 Wants=ModemManager.service

--- a/recipes-core/modem-service/modem-service.bb
+++ b/recipes-core/modem-service/modem-service.bb
@@ -1,4 +1,4 @@
-SUMMARY = "LibreScoot Modem Service"
+SUMMARY = "Librescoot Modem Service"
 HOMEPAGE = "https://github.com/librescoot/modem-service"
 LICENSE = "CC-BY-NC-SA-4.0"
 LIC_FILES_CHKSUM = "file://src/modem-service/LICENSE;md5=eb1e647870add0502f8f010b19de32af"

--- a/recipes-core/onboot-service/files/librescoot-onboot.service
+++ b/recipes-core/onboot-service/files/librescoot-onboot.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=LibreScoot manual bootup script
+Description=Librescoot manual bootup script
 Wants=local-fs.target
 After=local-fs.target
 ConditionPathExists=/data/onboot.sh

--- a/recipes-core/pm-service/pm-service.bb
+++ b/recipes-core/pm-service/pm-service.bb
@@ -1,4 +1,4 @@
-SUMMARY = "LibreScoot Power Management Service"
+SUMMARY = "Librescoot Power Management Service"
 HOMEPAGE = "https://github.com/librescoot/pm-service"
 LICENSE = "AGPL-3.0"
 LIC_FILES_CHKSUM = "file://src/github.com/librescoot/pm-service/LICENSE;md5=eb1e647870add0502f8f010b19de32af"

--- a/recipes-core/settings-service/files/librescoot-settings.service
+++ b/recipes-core/settings-service/files/librescoot-settings.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=LibreScoot Settings Service
+Description=Librescoot Settings Service
 Requires=redis.service
 After=redis.service
 Before=librescoot-vehicle.service

--- a/recipes-core/settings-service/settings-service.bb
+++ b/recipes-core/settings-service/settings-service.bb
@@ -1,4 +1,4 @@
-SUMMARY = "LibreScoot Settings Service"
+SUMMARY = "Librescoot Settings Service"
 HOMEPAGE = "https://github.com/librescoot/settings-service"
 LICENSE = "CC-BY-NC-SA-4.0"
 LIC_FILES_CHKSUM = "file://src/github.com/librescoot/settings-service/LICENSE;md5=fb5d051e53001fdff7fec0f368f47190"

--- a/recipes-core/shell-config/files/librescoot-aliases-dbc.sh
+++ b/recipes-core/shell-config/files/librescoot-aliases-dbc.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# LibreScoot shell aliases for DBC
+# Librescoot shell aliases for DBC
 
 # Default redis-cli to connect to MDB
 alias redis-cli='redis-cli -h mdb'

--- a/recipes-core/shell-config/files/librescoot-aliases.sh
+++ b/recipes-core/shell-config/files/librescoot-aliases.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# LibreScoot shell aliases
+# Librescoot shell aliases
 
 # Redis CLI shortcuts
 alias hgetall='redis-cli hgetall'

--- a/recipes-core/shell-config/shell-config.bb
+++ b/recipes-core/shell-config/shell-config.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "LibreScoot shell configuration and aliases"
+DESCRIPTION = "Librescoot shell configuration and aliases"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 

--- a/recipes-core/systemd/systemd/tmp.conf
+++ b/recipes-core/systemd/systemd/tmp.conf
@@ -1,6 +1,6 @@
-# LibreScoot override of /usr/lib/tmpfiles.d/tmp.conf
+# Librescoot override of /usr/lib/tmpfiles.d/tmp.conf
 #
-# /var/tmp is a symlink to volatile/tmp on LibreScoot. Stock systemd's
+# /var/tmp is a symlink to volatile/tmp on Librescoot. Stock systemd's
 # "q /var/tmp 1777 root root 30d" errors out at boot because tmpfiles
 # type 'q' refuses to operate on non-directories:
 #

--- a/recipes-core/systemd/systemd/var.conf
+++ b/recipes-core/systemd/systemd/var.conf
@@ -1,6 +1,6 @@
-# LibreScoot override of /usr/lib/tmpfiles.d/var.conf
+# Librescoot override of /usr/lib/tmpfiles.d/var.conf
 #
-# /var/log is a symlink to volatile/log on LibreScoot (managed by base-files
+# /var/log is a symlink to volatile/log on Librescoot (managed by base-files
 # and 00-create-volatile.conf). Stock systemd's "d /var/log" entry errors
 # out at boot because tmpfiles type 'd' refuses to operate on non-directories:
 #

--- a/recipes-core/ums-service/files/librescoot-ums.service
+++ b/recipes-core/ums-service/files/librescoot-ums.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=LibreScoot UMS Service
+Description=Librescoot UMS Service
 Requires=redis.service
 After=redis.service
 After=librescoot-vehicle.service

--- a/recipes-core/ums-service/ums-service.bb
+++ b/recipes-core/ums-service/ums-service.bb
@@ -1,4 +1,4 @@
-SUMMARY = "LibreScoot UMS Service"
+SUMMARY = "Librescoot UMS Service"
 HOMEPAGE = "https://github.com/librescoot/ums-service"
 LICENSE = "CC-BY-NC-SA-4.0"
 LIC_FILES_CHKSUM = "file://src/github.com/librescoot/ums-service/LICENSE;md5=fb5d051e53001fdff7fec0f368f47190"

--- a/recipes-core/update-service/update-service.bb
+++ b/recipes-core/update-service/update-service.bb
@@ -1,4 +1,4 @@
-SUMMARY = "LibreScoot Update Service"
+SUMMARY = "Librescoot Update Service"
 HOMEPAGE = "https://github.com/librescoot/update-service"
 LICENSE = "AGPL-3.0-only"
 LIC_FILES_CHKSUM = "file://src/github.com/librescoot/update-service/LICENSE;md5=eb1e647870add0502f8f010b19de32af"

--- a/recipes-core/uplink-service/files/librescoot-uplink.service
+++ b/recipes-core/uplink-service/files/librescoot-uplink.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=LibreScoot Uplink Service (Redis-IPC)
+Description=Librescoot Uplink Service (Redis-IPC)
 After=network.target redis.service
 Requires=redis.service
 ConditionPathExists=/data/uplink-service/uplink.yaml

--- a/recipes-core/uplink-service/uplink-service.bb
+++ b/recipes-core/uplink-service/uplink-service.bb
@@ -1,4 +1,4 @@
-SUMMARY = "LibreScoot Uplink Service"
+SUMMARY = "Librescoot Uplink Service"
 HOMEPAGE = "https://github.com/librescoot/uplink-service"
 LICENSE = "AGPL-3.0-only"
 LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=eb1e647870add0502f8f010b19de32af"

--- a/recipes-core/vehicle-service/vehicle-service.bb
+++ b/recipes-core/vehicle-service/vehicle-service.bb
@@ -1,4 +1,4 @@
-SUMMARY = "LibreScoot Vehicle Service"
+SUMMARY = "Librescoot Vehicle Service"
 HOMEPAGE = "https://github.com/librescoot/vehicle-service"
 LICENSE = "CC-BY-NC-SA-4.0"
 LIC_FILES_CHKSUM = "file://src/vehicle-service/LICENSE;md5=fb5d051e53001fdff7fec0f368f47190"

--- a/recipes-core/version-service/version-service.bb
+++ b/recipes-core/version-service/version-service.bb
@@ -1,4 +1,4 @@
-SUMMARY = "LibreScoot Version Service"
+SUMMARY = "Librescoot Version Service"
 HOMEPAGE = "https://github.com/librescoot/version-service"
 LICENSE = "AGPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://src/github.com/librescoot/version-service/LICENSE;md5=eb1e647870add0502f8f010b19de32af"

--- a/recipes-fsl/images/librescoot-dbc-image.bb
+++ b/recipes-fsl/images/librescoot-dbc-image.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "LibreScoot DBC image"
+DESCRIPTION = "Librescoot DBC image"
 LICENSE = "MIT"
 
 inherit core-image

--- a/recipes-fsl/images/librescoot-mdb-image.bb
+++ b/recipes-fsl/images/librescoot-mdb-image.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "LibreScoot MDB image"
+DESCRIPTION = "Librescoot MDB image"
 LICENSE = "MIT"
 
 inherit core-image

--- a/recipes-graphics/boot-animation/boot-animation.bb
+++ b/recipes-graphics/boot-animation/boot-animation.bb
@@ -1,4 +1,4 @@
-SUMMARY = "Boot animation for LibreScoot DBC"
+SUMMARY = "Boot animation for Librescoot DBC"
 DESCRIPTION = "Renders Lottie JSON animations to /dev/fb0 using ThorVG"
 HOMEPAGE = "https://github.com/librescoot/boot-animation"
 LICENSE = "CC-BY-NC-4.0"

--- a/recipes-graphics/carplay-service/carplay-service.bb
+++ b/recipes-graphics/carplay-service/carplay-service.bb
@@ -1,4 +1,4 @@
-SUMMARY = "LibreScoot Carplay Service"
+SUMMARY = "Librescoot Carplay Service"
 HOMEPAGE = "https://github.com/librescoot/carplay-service"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://src/github.com/mzyy94/gocarplay/LICENSE;md5=6560d1f6d5f413db4997dffd12eed3ce"

--- a/recipes-graphics/dbc-dispatcher/dbc-dispatcher.bb
+++ b/recipes-graphics/dbc-dispatcher/dbc-dispatcher.bb
@@ -1,4 +1,4 @@
-SUMMARY = "LibreScoot DBC Display Dispatcher"
+SUMMARY = "Librescoot DBC Display Dispatcher"
 HOMEPAGE = "https://github.com/librescoot/dbc-dispatcher"
 LICENSE = "CC-BY-NC-SA-4.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=444cf8f9f11901e2fa0b24a5562ca5fc"

--- a/recipes-graphics/scootui-qt/scootui-qt.bb
+++ b/recipes-graphics/scootui-qt/scootui-qt.bb
@@ -1,6 +1,6 @@
 SUMMARY = "ScootUI (Qt)"
 DESCRIPTION = "ScootUI instrument cluster UI - Qt/QML port"
-AUTHOR = "LibreScoot Contributors"
+AUTHOR = "Librescoot Contributors"
 HOMEPAGE = "https://github.com/librescoot/scootui-qt"
 SECTION = "graphics"
 


### PR DESCRIPTION
## Summary

Renames `LibreScoot` -> `Librescoot` across user-visible strings and code comments in 44 files.

What changed:
- `DISTRO_NAME` in both distro confs (lands in `/etc/os-release`)
- `SUMMARY` / `DESCRIPTION` / `AUTHOR` in 22 recipe files (package metadata)
- `Description=` in 13 systemd unit files (visible in `systemctl status` and journalctl)
- Inline comments in `librescoot-go.bbclass`, `tmp.conf`/`var.conf`, the shell-config aliases, and base-files `hosts`

Out of scope (left untouched on purpose):
- Historical journal captures under `docs/dbc-boot-analysis/` (rewriting them would falsify the recorded boot output)
- The data-server plan doc under `docs/superpowers/plans/` (frozen historical artifact)
- The kernel patch `From:` / `Signed-off-by:` lines in `recipes-kernel/linux/linux-fslc/0001-fbcon-show-boot-logo-regardless-of-loglevel.patch` (those are patch identity metadata, not user-visible)

## Test plan

- [ ] Build `librescoot-mdb-image` and confirm `/etc/os-release` shows `NAME="Librescoot"`
- [ ] Build `librescoot-dbc-image` and confirm the same on the DBC
- [ ] `systemctl status librescoot-vehicle` (etc.) shows the new `Description=`
- [ ] Package metadata (`opkg info <pkg>`) shows the new `Summary`